### PR TITLE
[codex] Add editorial design system

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,64 @@
+# Dhafin Editorial Design System
+
+Astro + Tailwind v4 design system for the Dhafin personal site.
+
+## Direction
+
+Minimal editorial portfolio with product-building proof first. The site should feel like a sharp creative product-builder profile: structured, readable, image-aware, and direct.
+
+## Tokens
+
+| Name | Value | Token | Role |
+| --- | --- | --- | --- |
+| Black Ink | `#2b2b2b` | `--color-black-ink` | Text, borders, headings |
+| Pure White | `#ffffff` | `--color-pure-white` | Page background, panels |
+| Frost Gray | `#f0efef` | `--color-frost-gray` | Subtle tags, quiet media tone |
+| Medium Gray | `#676767` | `--color-medium-gray` | Secondary copy |
+| Muted Taupe | `#faead9` | `--color-muted-taupe` | Warm section bands |
+| Electric Purple | `#8147ff` | `--color-electric-purple` | Primary CTA and focus accent |
+| Sunshine Yellow | `#ffd519` | `--color-sunshine-yellow` | Highlight media and selection |
+| Deep Indigo | `#6219ff` | `--color-deep-indigo` | Links |
+
+## Typography
+
+| Role | Token | Size | Line height | Tracking |
+| --- | --- | --- | --- | --- |
+| Caption | `--text-caption` | `0.75rem` | `1.4` | `0.04em` |
+| Body | `--text-body` | `1rem` | `1.55` | `0.005em` |
+| Meta | `--text-meta` | `0.8125rem` | `1.45` | `0.08em` |
+| Heading | `--text-heading` | `clamp(1.5625rem, 2.2vw, 2rem)` | `1.22` | `0.035em` |
+| Display | `--text-display` | `clamp(2.35rem, 7vw, 5.75rem)` | `0.98` | `0.018em` |
+
+Fallbacks:
+
+- Bradford -> Georgia
+- LabilVariable -> Open Sans / system sans
+- Labil -> Open Sans / system sans
+
+## Components
+
+- `Button`: ghost, category, pill, highlight variants.
+- `Tag`: filled or outline metadata chip.
+- `ArticleCard`: transparent listing card with bordered editorial media block.
+- `BaseLayout`: header, footer, page shell, canonical metadata.
+- `editorial-hero`: two-column desktop hero, single-column mobile.
+- `editorial-panel`: bordered support panel for proof/context.
+- `rule-list`: divider-led two-column editorial rows.
+- `token-swatch`: design QA swatch for `/style-preview`.
+
+## Routes
+
+- `/`
+- `/work`
+- `/writing`
+- `/about`
+- `/style-preview`
+
+## Rules
+
+- Product proof before chronology.
+- One filled primary CTA per page.
+- No shadows for elevation.
+- No rounded cards; only pill CTA uses `75px` radius.
+- Use Tailwind v4 `@theme` and `@utility` in `src/styles/global.css`.
+- Keep Sanity schemas, query layer, and preview auth outside this design-system slice.

--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -1,0 +1,35 @@
+---
+import Tag from './Tag.astro';
+
+interface Props {
+  title: string;
+  summary: string;
+  eyebrow: string;
+  tags?: string[];
+  href?: string;
+  tone?: string;
+  mark?: string;
+}
+
+const {
+  title,
+  summary,
+  eyebrow,
+  tags = [],
+  href = '#',
+  tone = 'var(--color-muted-taupe)',
+  mark = '01',
+} = Astro.props;
+---
+
+<article class="card">
+  <a class="card-media" href={href} aria-label={title} style={`--media-tone: ${tone};`}>
+    <span class="card-media-mark">{mark}</span>
+  </a>
+  <div class="card-meta">
+    <Tag>{eyebrow}</Tag>
+    {tags.map((tag) => <Tag outline>{tag}</Tag>)}
+  </div>
+  <h3 class="heading"><a class="card-link" href={href}>{title}</a></h3>
+  <p class="body-copy">{summary}</p>
+</article>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,0 +1,31 @@
+---
+type Variant = 'ghost' | 'category' | 'pill' | 'highlight';
+
+interface Props {
+  href?: string;
+  variant?: Variant;
+}
+
+const { href, variant = 'ghost' } = Astro.props;
+const variantClass =
+  variant === 'ghost'
+    ? ''
+    : {
+        category: 'button-category',
+        pill: 'button-pill',
+        highlight: 'button-highlight',
+      }[variant];
+const classes = ['button', variantClass].filter(Boolean).join(' ');
+---
+
+{
+  href ? (
+    <a class={classes} href={href}>
+      <slot />
+    </a>
+  ) : (
+    <button class={classes} type="button">
+      <slot />
+    </button>
+  )
+}

--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -1,0 +1,11 @@
+---
+interface Props {
+  outline?: boolean;
+}
+
+const { outline = false } = Astro.props;
+---
+
+<span class:list={['tag', outline && 'tag-outline']}>
+  <slot />
+</span>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -16,7 +16,7 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl);
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" class="antialiased">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -25,7 +25,25 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl);
     <link rel="canonical" href={canonicalUrl.toString()} />
   </head>
   <body>
-    <slot />
+    <header class="site-header">
+      <div class="page-shell site-header-inner">
+        <a class="site-brand" href="/" aria-label="Homepage">Dhafin</a>
+        <nav class="site-nav" aria-label="Primary">
+          <a class="site-nav-link" href="/work">Work</a>
+          <a class="site-nav-link" href="/writing">Writing</a>
+          <a class="site-nav-link" href="/about">About</a>
+          <a class="site-nav-link" href="/style-preview">Style</a>
+        </nav>
+      </div>
+    </header>
+    <main class="page-shell site-main isolate">
+      <slot />
+    </main>
+    <footer class="site-footer">
+      <div class="page-shell site-footer-inner">
+        <span>Dhafin</span>
+        <span>Product-shaped ideas into usable web experiences.</span>
+      </div>
+    </footer>
   </body>
 </html>
-

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,44 @@
+---
+import Button from '../components/Button.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="About | Dhafin"
+  description="About Dhafin, a product builder focused on design engineering and AI-assisted shipping."
+>
+  <section class="editorial-hero" aria-labelledby="about-title">
+    <div class="section">
+      <p class="eyebrow">About</p>
+      <h1 id="about-title" class="display">Focused product builder with creative range.</h1>
+      <p class="body-copy">
+        I shape, design, and ship 0-to-1 web products. Creative work is supporting proof:
+        taste, pacing, visual judgment, and ability to make abstract ideas concrete.
+      </p>
+      <div>
+        <Button href="/work" variant="pill">View work</Button>
+      </div>
+    </div>
+    <aside class="editorial-panel">
+      <h2 class="heading">Tools and habits</h2>
+      <div class="rule-list">
+        <div class="rule-item">
+          <p class="eyebrow">Build</p>
+          <p class="body-copy">Next.js, Astro, TypeScript, Tailwind CSS, PostgreSQL, Cloudflare.</p>
+        </div>
+        <div class="rule-item">
+          <p class="eyebrow">CMS</p>
+          <p class="body-copy">
+            Sanity for content-heavy launch workflows, Payload when product requirements justify it.
+          </p>
+        </div>
+        <div class="rule-item">
+          <p class="eyebrow">AI</p>
+          <p class="body-copy">
+            Codex and Claude as build partners, with product direction and UX judgment kept explicit.
+          </p>
+        </div>
+      </div>
+    </aside>
+  </section>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,6 @@
 ---
+import ArticleCard from '../components/ArticleCard.astro';
+import Button from '../components/Button.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
@@ -6,15 +8,99 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   title="Dhafin"
   description="Focused on design engineering, 0-to-1 SaaS workflows, and AI-assisted shipping."
 >
-  <main class="site-shell">
-    <section class="hero" aria-labelledby="hero-title">
-      <p class="eyebrow">Dhafin</p>
-      <h1 id="hero-title">I build product-shaped ideas into usable web experiences.</h1>
-      <p class="lede">
-        Focused on design engineering, 0-to-1 SaaS workflows, and AI-assisted shipping.
+  <section class="editorial-hero" aria-labelledby="home-title">
+    <div class="section">
+      <p class="eyebrow">Design engineering / 0-to-1 products</p>
+      <h1 id="home-title" class="display">I build product-shaped ideas into usable web experiences.</h1>
+      <p class="body-copy">
+        Focused on SaaS workflows, product direction, interface detail, and AI-assisted shipping.
       </p>
-      <a class="primary-link" href="/work">View work</a>
-    </section>
-  </main>
-</BaseLayout>
+      <div>
+        <Button href="/work" variant="pill">View work</Button>
+      </div>
+    </div>
+    <aside class="editorial-panel" aria-label="Profile summary">
+      <p class="heading">Taste, product sense, and fast build loops.</p>
+      <div class="stat-row">
+        <div class="stat-item">
+          <span class="stat-value tabular-nums">03</span>
+          <span class="stat-label">Selected products</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-value">AI</span>
+          <span class="stat-label">Build partner</span>
+        </div>
+        <div class="stat-item">
+          <span class="stat-value">UX</span>
+          <span class="stat-label">Primary proof</span>
+        </div>
+      </div>
+      <p class="body-copy">
+        The site favors proof over self-description: product screenshots, case-study notes,
+        launch decisions, and direct contact paths.
+      </p>
+    </aside>
+  </section>
 
+  <section class="section" aria-labelledby="focus-title">
+    <h2 id="focus-title" class="heading">Current position</h2>
+    <div class="rule-list">
+      <div class="rule-item">
+        <p class="eyebrow">Build</p>
+        <p class="body-copy">
+          Shape rough ideas into understandable product flows, especially onboarding,
+          dashboards, and first useful workflows.
+        </p>
+      </div>
+      <div class="rule-item">
+        <p class="eyebrow">Design</p>
+        <p class="body-copy">
+          Use restrained editorial structure, clear information hierarchy, and product
+          screenshots instead of decorative portfolio effects.
+        </p>
+      </div>
+      <div class="rule-item">
+        <p class="eyebrow">Ship</p>
+        <p class="body-copy">
+          Work quickly with AI-assisted implementation, then make product and UX decisions with
+          deliberate human judgment.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section section-taupe" aria-labelledby="work-title">
+    <div class="section">
+      <h2 id="work-title" class="heading">Selected work</h2>
+      <div class="grid-three">
+        <ArticleCard
+          title="Invitasi"
+          eyebrow="SaaS workflow"
+          summary="Wedding invitation platform for polished invitations, RSVP management, and planning workflows."
+          tags={['Product direction', 'Interface design']}
+          href="/work/invitasi"
+          tone="var(--color-sunshine-yellow)"
+          mark="I"
+        />
+        <ArticleCard
+          title="Devault"
+          eyebrow="Community SaaS"
+          summary="Discord resource capture and monitoring workspace for teams that live in chat."
+          tags={['Dashboard UX', 'Product build']}
+          href="/work/devault"
+          tone="var(--color-frost-gray)"
+          mark="D"
+        />
+        <ArticleCard
+          title="Standout Headshot"
+          eyebrow="AI product"
+          summary="Fast professional headshot generation flow shaped around conversion and clarity."
+          tags={['AI workflow', 'UX direction']}
+          href="/work/standout-headshot"
+          tone="var(--color-electric-purple)"
+          mark="S"
+        />
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/style-preview.astro
+++ b/src/pages/style-preview.astro
@@ -1,0 +1,106 @@
+---
+import ArticleCard from '../components/ArticleCard.astro';
+import Button from '../components/Button.astro';
+import Tag from '../components/Tag.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Style Preview | Dhafin">
+  <section class="section" aria-labelledby="preview-title">
+    <p class="eyebrow">Editorial design system</p>
+    <h1 id="preview-title" class="display">Sharp structure, warm proof, vivid calls to action.</h1>
+    <p class="body-copy">
+      Implementation preview for global Tailwind v4 tokens, typography, layout utilities, and
+      component primitives.
+    </p>
+  </section>
+
+  <section class="section" aria-labelledby="type-title">
+    <h2 id="type-title" class="heading">Typography</h2>
+    <div class="rule-list">
+      <div class="rule-item">
+        <p class="eyebrow">Display</p>
+        <p class="display">Product-shaped ideas.</p>
+      </div>
+      <div class="rule-item">
+        <p class="eyebrow">Heading</p>
+        <p class="heading">Case-study notes, proof rows, and compact page sections.</p>
+      </div>
+      <div class="rule-item">
+        <p class="eyebrow">Body</p>
+        <p class="body-copy">
+          Bradford fallback uses Georgia for a readable editorial voice while custom fonts are
+          unavailable.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section" aria-labelledby="button-title">
+    <h2 id="button-title" class="heading">Buttons and Tags</h2>
+    <div class="grid-auto">
+      <Button>Ghost button</Button>
+      <Button variant="category">Category label</Button>
+      <Button variant="pill">Pill action</Button>
+      <Button variant="highlight">Highlighted</Button>
+      <Tag>Build Logs</Tag>
+      <Tag outline>Product Notes</Tag>
+    </div>
+  </section>
+
+  <section class="section" aria-labelledby="color-title">
+    <h2 id="color-title" class="heading">Color</h2>
+    <div class="token-grid">
+      <div
+        class="token-swatch"
+        style="--swatch: var(--color-black-ink); --swatch-text: var(--color-pure-white);"
+      >
+        Black Ink
+      </div>
+      <div
+        class="token-swatch"
+        style="--swatch: var(--color-electric-purple); --swatch-text: var(--color-pure-white);"
+      >
+        Electric Purple
+      </div>
+      <div class="token-swatch" style="--swatch: var(--color-sunshine-yellow);">
+        Sunshine Yellow
+      </div>
+      <div class="token-swatch" style="--swatch: var(--color-muted-taupe);">Muted Taupe</div>
+      <div class="token-swatch" style="--swatch: var(--color-frost-gray);">Frost Gray</div>
+      <div class="token-swatch risograph-band">Risograph Band</div>
+    </div>
+  </section>
+
+  <section class="section section-taupe" aria-labelledby="card-title">
+    <div class="section">
+      <h2 id="card-title" class="heading">Cards</h2>
+      <div class="grid-three">
+        <ArticleCard
+          title="Invitasi"
+          eyebrow="SaaS workflow"
+          summary="Proof-led content card with image-first hierarchy and compact editorial rhythm."
+          tags={['Product direction', 'RSVP']}
+          tone="var(--color-sunshine-yellow)"
+          mark="01"
+        />
+        <ArticleCard
+          title="Devault"
+          eyebrow="Community SaaS"
+          summary="Transparent card primitive, no shadow, no radius, strong spacing and typography."
+          tags={['Dashboard', 'Discord']}
+          tone="var(--color-frost-gray)"
+          mark="02"
+        />
+        <ArticleCard
+          title="Standout Headshot"
+          eyebrow="AI product"
+          summary="Primitive supports selected work, writing cards, and archive listings."
+          tags={['AI', 'Conversion']}
+          tone="var(--color-electric-purple)"
+          mark="03"
+        />
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -1,0 +1,47 @@
+---
+import ArticleCard from '../components/ArticleCard.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="Work | Dhafin" description="Selected product-building work by Dhafin.">
+  <section class="section" aria-labelledby="work-title">
+    <p class="eyebrow">Selected work</p>
+    <h1 id="work-title" class="display">Product proof before chronology.</h1>
+    <p class="body-copy">
+      Work is ordered by positioning strength: product direction, UX clarity, shipped workflows,
+      and evidence of taste.
+    </p>
+  </section>
+
+  <section class="section section-taupe" aria-label="Selected product cards">
+    <div class="grid-three">
+      <ArticleCard
+        title="Invitasi"
+        eyebrow="Ongoing SaaS"
+        summary="Wedding invitation platform for couples and organizers to publish invitations, manage RSVPs, and grow into planning workflows."
+        tags={['Onboarding', 'RSVP', 'Builder']}
+        href="/work/invitasi"
+        tone="var(--color-sunshine-yellow)"
+        mark="I"
+      />
+      <ArticleCard
+        title="Devault"
+        eyebrow="Live product"
+        summary="Community SaaS for Discord teams to save useful resources from chat and monitor high-signal channels."
+        tags={['Community workflow', 'Dashboard']}
+        href="/work/devault"
+        tone="var(--color-frost-gray)"
+        mark="D"
+      />
+      <ArticleCard
+        title="Standout Headshot"
+        eyebrow="AI product"
+        summary="Professional headshot generation product shaped around fast comprehension and conversion."
+        tags={['AI images', 'Conversion']}
+        href="/work/standout-headshot"
+        tone="var(--color-electric-purple)"
+        mark="S"
+      />
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -1,0 +1,48 @@
+---
+import ArticleCard from '../components/ArticleCard.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout
+  title="Writing | Dhafin"
+  description="Build logs, product notes, creative process, and personal lessons by Dhafin."
+>
+  <section class="section" aria-labelledby="writing-title">
+    <p class="eyebrow">Writing</p>
+    <h1 id="writing-title" class="display">Build notes with a product lens.</h1>
+    <p class="body-copy">
+      The writing feed starts small: lessons from rebuilding the site, product-building notes,
+      and creative-process reflections.
+    </p>
+  </section>
+
+  <section class="grid-three" aria-label="Planned writing">
+    <ArticleCard
+      title="Why I am rebuilding my site around product building"
+      eyebrow="Product Notes"
+      summary="A positioning note on making selected product work easier to judge in the first ten seconds."
+      tags={['Planned']}
+      href="/writing/why-i-am-rebuilding-my-site-around-product-building"
+      tone="var(--color-muted-taupe)"
+      mark="01"
+    />
+    <ArticleCard
+      title="What video work taught me about product building"
+      eyebrow="Creative Process"
+      summary="How narrative, pacing, and visual judgment from media work transfer into product design."
+      tags={['Planned']}
+      href="/writing/what-video-work-taught-me-about-product-building"
+      tone="var(--color-frost-gray)"
+      mark="02"
+    />
+    <ArticleCard
+      title="How I use AI as a build partner"
+      eyebrow="Build Logs"
+      summary="A practical look at AI-assisted implementation without outsourcing product judgment."
+      tags={['Draft idea']}
+      href="/writing"
+      tone="var(--color-sunshine-yellow)"
+      mark="03"
+    />
+  </section>
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,46 @@
 @import "tailwindcss";
 
+:root {
+  color-scheme: light;
+
+  --color-black-ink: #2b2b2b;
+  --color-pure-white: #ffffff;
+  --color-frost-gray: #f0efef;
+  --color-medium-gray: #676767;
+  --color-muted-taupe: #faead9;
+  --color-electric-purple: #8147ff;
+  --color-sunshine-yellow: #ffd519;
+  --color-deep-indigo: #6219ff;
+  --gradient-risograph: linear-gradient(rgb(255 255 255) 20%, rgb(0 0 0 / 8%) 20%);
+
+  --font-bradford: Georgia, "Times New Roman", serif;
+  --font-labilvariable: "Open Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-labil: "Open Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+
+  --text-caption: 0.75rem;
+  --leading-caption: 1.4;
+  --tracking-caption: 0.04em;
+  --text-body: 1rem;
+  --leading-body: 1.55;
+  --tracking-body: 0.005em;
+  --text-meta: 0.8125rem;
+  --leading-meta: 1.45;
+  --tracking-meta: 0.08em;
+  --text-heading: clamp(1.5625rem, 2.2vw, 2rem);
+  --leading-heading: 1.22;
+  --tracking-heading: 0.035em;
+  --text-display: clamp(2.35rem, 7vw, 5.75rem);
+  --leading-display: 0.98;
+  --tracking-display: 0.018em;
+
+  --page-max-width: 1200px;
+  --section-gap: clamp(2.5rem, 7vw, 5rem);
+  --radius-default: 0;
+  --radius-buttons: 75px;
+  --border-ink: 1px solid var(--color-black-ink);
+  --border-subtle: 1px solid rgb(43 43 43 / 14%);
+}
+
 @theme {
   --color-black-ink: #2b2b2b;
   --color-pure-white: #ffffff;
@@ -10,48 +51,33 @@
   --color-sunshine-yellow: #ffd519;
   --color-deep-indigo: #6219ff;
 
-  --font-bradford: Georgia, serif;
+  --font-bradford: Georgia, "Times New Roman", serif;
   --font-labilvariable: "Open Sans", ui-sans-serif, system-ui, sans-serif;
   --font-labil: "Open Sans", ui-sans-serif, system-ui, sans-serif;
 
-  --spacing-4: 4px;
-  --spacing-5: 5px;
-  --spacing-8: 8px;
-  --spacing-10: 10px;
-  --spacing-12: 12px;
-  --spacing-13: 13px;
-  --spacing-15: 15px;
-  --spacing-16: 16px;
-  --spacing-20: 20px;
-  --spacing-30: 30px;
-  --spacing-40: 40px;
-  --spacing-60: 60px;
-  --spacing-80: 80px;
-  --spacing-113: 113px;
-  --spacing-191: 191px;
+  --text-caption: 0.75rem;
+  --text-body: 1rem;
+  --text-meta: 0.8125rem;
+  --text-heading: clamp(1.5625rem, 2.2vw, 2rem);
+  --text-display: clamp(2.35rem, 7vw, 5.75rem);
+
+  --spacing-4: 0.25rem;
+  --spacing-5: 0.3125rem;
+  --spacing-8: 0.5rem;
+  --spacing-10: 0.625rem;
+  --spacing-12: 0.75rem;
+  --spacing-13: 0.8125rem;
+  --spacing-15: 0.9375rem;
+  --spacing-16: 1rem;
+  --spacing-20: 1.25rem;
+  --spacing-30: 1.875rem;
+  --spacing-40: 2.5rem;
+  --spacing-60: 3.75rem;
+  --spacing-80: 5rem;
 
   --radius-full: 75px;
-}
-
-:root {
-  color-scheme: light;
-  --color-black-ink: #2b2b2b;
-  --color-pure-white: #ffffff;
-  --color-frost-gray: #f0efef;
-  --color-medium-gray: #676767;
-  --color-muted-taupe: #faead9;
-  --color-electric-purple: #8147ff;
-  --color-sunshine-yellow: #ffd519;
-  --color-deep-indigo: #6219ff;
-
-  --font-bradford: Georgia, serif;
-  --font-labilvariable: "Open Sans", ui-sans-serif, system-ui, sans-serif;
-  --font-labil: "Open Sans", ui-sans-serif, system-ui, sans-serif;
-
-  --page-max-width: 1200px;
-  --section-gap: 40px;
-  --radius-default: 0;
   --radius-buttons: 75px;
+  --radius-default: 0px;
 }
 
 * {
@@ -62,87 +88,441 @@ html {
   background: var(--color-pure-white);
   color: var(--color-black-ink);
   font-family: var(--font-bradford);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
   text-rendering: optimizeLegibility;
 }
 
 body {
   margin: 0;
+  min-width: 320px;
   min-height: 100vh;
+  background:
+    linear-gradient(90deg, rgb(43 43 43 / 4%) 1px, transparent 1px) 0 0 / 25% 100%,
+    var(--color-pure-white);
+}
+
+body,
+button,
+input,
+textarea,
+select {
+  font: inherit;
 }
 
 a {
-  color: inherit;
+  color: var(--color-deep-indigo);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
 }
 
-.site-shell {
-  margin: 0 auto;
-  max-width: var(--page-max-width);
-  padding: 40px 20px;
+a:hover {
+  color: var(--color-electric-purple);
 }
 
-.hero {
-  align-content: end;
-  border: 1px solid var(--color-black-ink);
-  min-height: calc(100vh - 80px);
-  padding: clamp(24px, 5vw, 60px);
+img,
+svg {
+  display: block;
+  max-width: 100%;
 }
 
-.eyebrow,
-.primary-link {
-  font-family: var(--font-labil);
-  font-size: 13px;
-  letter-spacing: 0.091em;
-  text-transform: uppercase;
+button,
+input,
+textarea,
+select {
+  border-radius: var(--radius-default);
 }
 
-.eyebrow {
-  margin: 0 0 40px;
+button {
+  cursor: pointer;
 }
 
-h1 {
-  font-family: var(--font-labilvariable);
-  font-size: clamp(40px, 8vw, 96px);
-  font-weight: 400;
-  letter-spacing: 0.091em;
-  line-height: 1.08;
-  margin: 0;
-  max-width: 980px;
+::selection {
+  background: var(--color-sunshine-yellow);
+  color: var(--color-black-ink);
 }
 
-.lede {
-  color: var(--color-medium-gray);
-  font-size: 17px;
-  line-height: 1.53;
-  margin: 30px 0 0;
-  max-width: 560px;
-}
-
-.primary-link {
-  background: var(--color-electric-purple);
-  border: 1px solid var(--color-electric-purple);
-  border-radius: var(--radius-buttons);
-  color: var(--color-pure-white);
-  display: inline-flex;
-  margin-top: 40px;
-  padding: 10px 20px;
-  text-decoration: none;
-}
-
-.primary-link:focus-visible {
-  outline: 3px solid var(--color-sunshine-yellow);
+:focus-visible {
+  outline: 2px solid var(--color-electric-purple);
   outline-offset: 3px;
 }
 
-@media (max-width: 720px) {
-  .site-shell {
-    padding: 15px;
+@utility page-shell {
+  width: min(100% - 2rem, var(--page-max-width));
+  margin-inline: auto;
+}
+
+@utility site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: var(--border-ink);
+  background: color-mix(in srgb, var(--color-pure-white) 92%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+@utility site-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-20);
+  min-height: 4rem;
+}
+
+@utility site-brand {
+  color: var(--color-black-ink);
+  font-family: var(--font-labilvariable);
+  font-size: var(--text-meta);
+  line-height: var(--leading-meta);
+  letter-spacing: var(--tracking-meta);
+  text-decoration: none;
+}
+
+@utility site-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-10);
+}
+
+@utility site-nav-link {
+  color: var(--color-black-ink);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+  text-decoration: none;
+}
+
+@utility site-main {
+  display: grid;
+  gap: var(--section-gap);
+  padding-block: var(--spacing-60) var(--spacing-80);
+}
+
+@utility site-footer {
+  border-top: var(--border-ink);
+  padding-block: var(--spacing-20);
+  background: var(--color-pure-white);
+}
+
+@utility site-footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-20);
+  color: var(--color-medium-gray);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+@utility eyebrow {
+  margin: 0;
+  color: var(--color-black-ink);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  font-weight: 400;
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+@utility display {
+  margin: 0;
+  max-width: 11ch;
+  font-family: var(--font-labilvariable);
+  font-size: var(--text-display);
+  font-weight: 400;
+  line-height: var(--leading-display);
+  letter-spacing: var(--tracking-display);
+  text-wrap: balance;
+}
+
+@utility heading {
+  margin: 0;
+  max-width: 20ch;
+  font-family: var(--font-labilvariable);
+  font-size: var(--text-heading);
+  font-weight: 400;
+  line-height: var(--leading-heading);
+  letter-spacing: var(--tracking-heading);
+  text-wrap: balance;
+}
+
+@utility body-copy {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--color-medium-gray);
+  font-family: var(--font-bradford);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
+  letter-spacing: var(--tracking-body);
+  text-wrap: pretty;
+}
+
+@utility button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  border: var(--border-ink);
+  border-radius: var(--radius-default);
+  padding: 0.75rem 0.875rem;
+  background: transparent;
+  color: var(--color-black-ink);
+  font-family: var(--font-bradford);
+  font-size: var(--text-body);
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: var(--tracking-body);
+  text-decoration: none;
+  transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+@utility button-hover {
+  background: var(--color-black-ink);
+  color: var(--color-pure-white);
+  transform: translateY(-1px);
+}
+
+@utility button-category {
+  background: var(--color-muted-taupe);
+}
+
+@utility button-pill {
+  min-height: 2.5rem;
+  border-color: var(--color-pure-white);
+  border-radius: var(--radius-buttons);
+  padding: 0 var(--spacing-20);
+  background: var(--color-electric-purple);
+  color: var(--color-pure-white);
+  font-family: var(--font-labilvariable);
+}
+
+@utility button-highlight {
+  border-color: var(--color-black-ink);
+  background: var(--color-sunshine-yellow);
+  color: var(--color-black-ink);
+  font-family: var(--font-labilvariable);
+}
+
+.button:hover {
+  @apply button-hover;
+}
+
+.button-pill:hover {
+  border-color: var(--color-black-ink);
+  background: var(--color-black-ink);
+}
+
+.button-highlight:hover {
+  background: var(--color-electric-purple);
+  color: var(--color-pure-white);
+}
+
+@utility tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.625rem;
+  border-radius: var(--radius-default);
+  padding: var(--spacing-5) var(--spacing-10);
+  background: var(--color-frost-gray);
+  color: var(--color-black-ink);
+  font-family: var(--font-bradford);
+  font-size: var(--text-caption);
+  font-weight: 400;
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+@utility tag-outline {
+  border: var(--border-ink);
+  background: transparent;
+}
+
+@utility card {
+  display: grid;
+  gap: var(--spacing-10);
+  min-width: 0;
+  border-radius: var(--radius-default);
+  background: transparent;
+}
+
+@utility card-media {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border: var(--border-ink);
+  background:
+    linear-gradient(135deg, transparent 0 48%, rgb(43 43 43 / 100%) 48% 52%, transparent 52%),
+    var(--media-tone, var(--color-muted-taupe));
+}
+
+@utility card-media-mark {
+  position: absolute;
+  right: var(--spacing-12);
+  bottom: var(--spacing-10);
+  color: var(--color-black-ink);
+  font-family: var(--font-labilvariable);
+  font-size: clamp(2rem, 6vw, 4rem);
+  line-height: 1;
+  letter-spacing: var(--tracking-heading);
+}
+
+@utility card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-5);
+}
+
+@utility card-link {
+  color: var(--color-black-ink);
+  text-decoration: none;
+}
+
+@utility section {
+  display: grid;
+  gap: var(--spacing-20);
+}
+
+@utility section-taupe {
+  margin-inline: calc(50% - 50vw);
+  padding: var(--spacing-60) max(1rem, calc((100vw - var(--page-max-width)) / 2));
+  background: var(--color-muted-taupe);
+}
+
+@utility editorial-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(17rem, 5fr);
+  gap: var(--spacing-40);
+  align-items: end;
+  min-height: clamp(32rem, 72svh, 46rem);
+}
+
+@utility editorial-panel {
+  display: grid;
+  gap: var(--spacing-20);
+  border: var(--border-ink);
+  padding: var(--spacing-20);
+  background: var(--color-pure-white);
+}
+
+@utility stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: var(--border-ink);
+  border-bottom: var(--border-ink);
+}
+
+@utility stat-item {
+  display: grid;
+  gap: var(--spacing-5);
+  padding: var(--spacing-16);
+}
+
+@utility stat-value {
+  font-family: var(--font-labilvariable);
+  font-size: var(--text-heading);
+  line-height: var(--leading-heading);
+  letter-spacing: var(--tracking-heading);
+}
+
+@utility stat-label {
+  color: var(--color-medium-gray);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+@utility grid-auto {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 17rem), 1fr));
+  gap: var(--spacing-20);
+}
+
+@utility grid-three {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--spacing-20);
+}
+
+@utility token-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
+  gap: var(--spacing-10);
+}
+
+@utility token-swatch {
+  display: grid;
+  min-height: 8rem;
+  align-content: end;
+  border: var(--border-ink);
+  padding: var(--spacing-12);
+  background: var(--swatch);
+  color: var(--swatch-text, var(--color-black-ink));
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+@utility rule-list {
+  display: grid;
+  gap: 0;
+  border-top: var(--border-ink);
+}
+
+@utility rule-item {
+  display: grid;
+  grid-template-columns: minmax(8rem, 1fr) minmax(0, 2fr);
+  gap: var(--spacing-20);
+  border-bottom: var(--border-ink);
+  padding-block: var(--spacing-16);
+}
+
+@utility risograph-band {
+  border: var(--border-ink);
+  background: var(--gradient-risograph);
+  background-size: 100% 10px;
+}
+
+@media (max-width: 760px) {
+  .page-shell {
+    width: min(100% - 1.5rem, var(--page-max-width));
   }
 
-  .hero {
-    min-height: calc(100vh - 30px);
+  .site-header-inner,
+  .site-footer-inner {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: flex-start;
+    padding-block: var(--spacing-12);
   }
 
-  h1 {
-    font-size: 40px;
+  .site-nav {
+    flex-wrap: wrap;
+  }
+
+  .site-main {
+    padding-block: var(--spacing-40) var(--spacing-60);
+  }
+
+  .editorial-hero,
+  .grid-three,
+  .rule-item {
+    grid-template-columns: 1fr;
+  }
+
+  .editorial-hero {
+    min-height: auto;
+  }
+
+  .stat-row {
+    grid-template-columns: 1fr;
+  }
+
+  .section-taupe {
+    padding-inline: 0.75rem;
   }
 }


### PR DESCRIPTION
## What changed

- Added Tailwind v4 editorial design tokens and reusable CSS utilities for the personal site shell.
- Added component primitives for buttons, tags, and article cards.
- Reworked the home page around product-building proof and selected work.
- Added static `/work`, `/writing`, `/about`, and `/style-preview` routes.
- Added `DESIGN.md` documenting the implemented tokens, components, routes, and design rules.

## Why

Issue #3 needs the editorial design-system layer in place before later content, Sanity query, and preview work builds on top of it. This PR keeps the slice focused on global styling, primitives, responsive page structure, and a design preview route.

## Impact

The site now has a reusable visual foundation for portfolio pages while leaving Sanity schemas, data queries, and preview auth untouched.

## Validation

- `pnpm run build`
- Astro check passed with 0 errors and 0 warnings.
- Static prerender generated `/`, `/work`, `/writing`, `/about`, and `/style-preview`.

Closes #3