### PR TITLE
Build writing section with rich content blocks

### DIFF
--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -1,0 +1,308 @@
+---
+import type { PortableTextBody, SanityImage } from '../sanity/published';
+
+interface Props {
+  body: PortableTextBody;
+}
+
+type PortableSpan = {
+  _key?: string;
+  _type?: string;
+  marks?: string[];
+  text?: string;
+};
+
+type PortableMark = {
+  _key?: string;
+  _type?: string;
+  href?: string;
+};
+
+type PortableBlock = {
+  _key?: string;
+  _type?: string;
+  children?: PortableSpan[];
+  listItem?: 'bullet' | 'number';
+  markDefs?: PortableMark[];
+  style?: 'normal' | 'h2' | 'h3' | 'blockquote';
+};
+
+type GalleryBlock = {
+  _key?: string;
+  _type?: string;
+  images?: SanityImage[];
+};
+
+type YouTubeBlock = {
+  _key?: string;
+  _type?: string;
+  title?: string;
+  url?: string;
+};
+
+type CalloutBlock = {
+  _key?: string;
+  _type?: string;
+  text?: string;
+  title?: string;
+  tone?: 'note' | 'product' | 'warning';
+};
+
+type CodeBlock = {
+  _key?: string;
+  _type?: string;
+  code?: string;
+  filename?: string;
+  language?: string;
+};
+
+type WorkReferenceBlock = {
+  _key?: string;
+  _type?: string;
+  label?: string;
+  work?: {
+    slug?: string;
+    summary?: string;
+    title?: string;
+  };
+};
+
+type ListNode = {
+  _key: string;
+  _type: 'list';
+  items: PortableBlock[];
+  listItem: 'bullet' | 'number';
+};
+
+type RichNode = PortableBlock | GalleryBlock | YouTubeBlock | CalloutBlock | CodeBlock | WorkReferenceBlock | ListNode;
+
+const { body } = Astro.props;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asBlock(value: unknown): RichNode | null {
+  return isRecord(value) ? (value as RichNode) : null;
+}
+
+function isListNode(value: RichNode | undefined): value is ListNode {
+  return value?._type === 'list';
+}
+
+function getKey(node: RichNode, index: number): string {
+  return typeof node._key === 'string' ? node._key : `node-${index}`;
+}
+
+function toNodes(blocks: PortableTextBody): RichNode[] {
+  const nodes: RichNode[] = [];
+
+  blocks.map(asBlock).forEach((block, index) => {
+    if (!block) {
+      return;
+    }
+
+      if ('listItem' in block && block.listItem) {
+      const previous = nodes.at(-1);
+
+      if (isListNode(previous) && previous.listItem === block.listItem) {
+        previous.items.push(block);
+        return;
+      }
+
+      nodes.push({
+        _key: `list-${getKey(block, index)}`,
+        _type: 'list',
+        items: [block],
+        listItem: block.listItem,
+      });
+      return;
+    }
+
+    nodes.push(block);
+  });
+
+  return nodes;
+}
+
+function getText(block: PortableBlock): string {
+  return (block.children ?? [])
+    .map((child) => (typeof child.text === 'string' ? child.text : ''))
+    .join('');
+}
+
+function getMarkDef(block: PortableBlock, key: string): PortableMark | undefined {
+  return block.markDefs?.find((mark) => mark._key === key);
+}
+
+function getYouTubeId(url: string | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(url);
+
+    if (parsed.hostname === 'youtu.be') {
+      return parsed.pathname.slice(1) || null;
+    }
+
+    if (parsed.hostname.includes('youtube.com')) {
+      return parsed.searchParams.get('v') || parsed.pathname.split('/').filter(Boolean).at(-1) || null;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+const nodes = toNodes(body);
+---
+
+<div class="rich-text">
+  {
+    nodes.map((node) => {
+      if (isListNode(node)) {
+        const Tag = node.listItem === 'number' ? 'ol' : 'ul';
+
+        return (
+          <Tag class="rich-list">
+            {node.items.map((item: PortableBlock) => <li>{getText(item)}</li>)}
+          </Tag>
+        );
+      }
+
+      if (node._type === 'block') {
+        const block = node as PortableBlock;
+        const text = getText(block);
+
+        if (block.style === 'h2') {
+          return <h2 class="rich-heading">{text}</h2>;
+        }
+
+        if (block.style === 'h3') {
+          return <h3 class="rich-subheading">{text}</h3>;
+        }
+
+        if (block.style === 'blockquote') {
+          return <blockquote class="rich-quote">{text}</blockquote>;
+        }
+
+        return (
+          <p>
+            {(block.children ?? []).map((child) => {
+              const childText = typeof child.text === 'string' ? child.text : '';
+              const linkMark = child.marks
+                ?.map((mark) => getMarkDef(block, mark))
+                .find((mark) => mark?._type === 'link' && mark.href);
+
+              return linkMark?.href ? <a href={linkMark.href}>{childText}</a> : childText;
+            })}
+          </p>
+        );
+      }
+
+      if (node._type === 'imageBlock') {
+        const image = node as SanityImage;
+        const dimensions = image.asset?.metadata?.dimensions;
+
+        return (
+          <figure class="rich-figure">
+            <img
+              src={image.asset.url}
+              alt={image.alt}
+              width={dimensions?.width}
+              height={dimensions?.height}
+              loading="lazy"
+            />
+            {image.caption && <figcaption>{image.caption}</figcaption>}
+          </figure>
+        );
+      }
+
+      if (node._type === 'gallery') {
+        const gallery = node as GalleryBlock;
+
+        return (
+          <div class="rich-gallery">
+            {(gallery.images ?? []).map((image) => {
+              const dimensions = image.asset?.metadata?.dimensions;
+
+              return (
+                <figure>
+                  <img
+                    src={image.asset.url}
+                    alt={image.alt}
+                    width={dimensions?.width}
+                    height={dimensions?.height}
+                    loading="lazy"
+                  />
+                  {image.caption && <figcaption>{image.caption}</figcaption>}
+                </figure>
+              );
+            })}
+          </div>
+        );
+      }
+
+      if (node._type === 'youtubeEmbed') {
+        const embed = node as YouTubeBlock;
+        const videoId = getYouTubeId(embed.url);
+
+        return videoId ? (
+          <figure class="rich-video">
+            <iframe
+              src={`https://www.youtube-nocookie.com/embed/${videoId}`}
+              title={embed.title || 'Embedded YouTube video'}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowfullscreen
+              loading="lazy"
+            />
+            {embed.title && <figcaption>{embed.title}</figcaption>}
+          </figure>
+        ) : null;
+      }
+
+      if (node._type === 'callout') {
+        const callout = node as CalloutBlock;
+
+        return (
+          <aside class:list={['rich-callout', callout.tone && `rich-callout-${callout.tone}`]}>
+            {callout.title && <p class="rich-callout-title">{callout.title}</p>}
+            <p>{callout.text}</p>
+          </aside>
+        );
+      }
+
+      if (node._type === 'codeBlock') {
+        const code = node as CodeBlock;
+
+        return (
+          <figure class="rich-code">
+            {(code.filename || code.language) && (
+              <figcaption>{[code.filename, code.language].filter(Boolean).join(' / ')}</figcaption>
+            )}
+            <pre><code>{code.code}</code></pre>
+          </figure>
+        );
+      }
+
+      if (node._type === 'workReference') {
+        const reference = node as WorkReferenceBlock;
+
+        return reference.work?.slug ? (
+          <aside class="rich-work-reference">
+            <p class="eyebrow">{reference.label || 'Related work'}</p>
+            <h3 class="heading">
+              <a href={`/work/${reference.work.slug}`}>{reference.work.title}</a>
+            </h3>
+            {reference.work.summary && <p class="body-copy">{reference.work.summary}</p>}
+          </aside>
+        ) : null;
+      }
+
+      return null;
+    })
+  }
+</div>

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -1,6 +1,18 @@
 ---
 import ArticleCard from '../components/ArticleCard.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { PublishedContentConfigError, getPublishedPosts } from '../sanity/published';
+import type { PublishedPost } from '../sanity/published';
+
+let posts: PublishedPost[] = [];
+
+try {
+  posts = await getPublishedPosts();
+} catch (error) {
+  if (!(error instanceof PublishedContentConfigError)) {
+    throw error;
+  }
+}
 ---
 
 <BaseLayout
@@ -16,33 +28,51 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </p>
   </section>
 
-  <section class="grid-three" aria-label="Planned writing">
-    <ArticleCard
-      title="Why I am rebuilding my site around product building"
-      eyebrow="Product Notes"
-      summary="A positioning note on making selected product work easier to judge in the first ten seconds."
-      tags={['Planned']}
-      href="/writing/why-i-am-rebuilding-my-site-around-product-building"
-      tone="var(--color-muted-taupe)"
-      mark="01"
-    />
-    <ArticleCard
-      title="What video work taught me about product building"
-      eyebrow="Creative Process"
-      summary="How narrative, pacing, and visual judgment from media work transfer into product design."
-      tags={['Planned']}
-      href="/writing/what-video-work-taught-me-about-product-building"
-      tone="var(--color-frost-gray)"
-      mark="02"
-    />
-    <ArticleCard
-      title="How I use AI as a build partner"
-      eyebrow="Build Logs"
-      summary="A practical look at AI-assisted implementation without outsourcing product judgment."
-      tags={['Draft idea']}
-      href="/writing"
-      tone="var(--color-sunshine-yellow)"
-      mark="03"
-    />
+  <section class="grid-three" aria-label="Published writing">
+    {
+      posts.length > 0 ? (
+        posts.map((post, index) => (
+          <ArticleCard
+            title={post.title}
+            eyebrow={post.category.title}
+            summary={post.excerpt}
+            tags={[new Date(post.publishedAt).getFullYear().toString()]}
+            href={`/writing/${post.slug}`}
+            tone={index % 2 === 0 ? 'var(--color-muted-taupe)' : 'var(--color-frost-gray)'}
+            mark={(index + 1).toString().padStart(2, '0')}
+          />
+        ))
+      ) : (
+        <>
+          <ArticleCard
+            title="Why I am rebuilding my site around product building"
+            eyebrow="Product Notes"
+            summary="A positioning note on making selected product work easier to judge in the first ten seconds."
+            tags={['Planned']}
+            href="/writing/why-i-am-rebuilding-my-site-around-product-building"
+            tone="var(--color-muted-taupe)"
+            mark="01"
+          />
+          <ArticleCard
+            title="What video work taught me about product building"
+            eyebrow="Creative Process"
+            summary="How narrative, pacing, and visual judgment from media work transfer into product design."
+            tags={['Planned']}
+            href="/writing/what-video-work-taught-me-about-product-building"
+            tone="var(--color-frost-gray)"
+            mark="02"
+          />
+          <ArticleCard
+            title="How I use AI as a build partner"
+            eyebrow="Build Logs"
+            summary="A practical look at AI-assisted implementation without outsourcing product judgment."
+            tags={['Draft idea']}
+            href="/writing"
+            tone="var(--color-sunshine-yellow)"
+            mark="03"
+          />
+        </>
+      )
+    }
   </section>
 </BaseLayout>

--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -1,0 +1,69 @@
+---
+import RichText from '../../components/RichText.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import {
+  PublishedContentConfigError,
+  getPublishedPostBySlug,
+  getPublishedPostStaticPaths,
+} from '../../sanity/published';
+
+export async function getStaticPaths() {
+  try {
+    return await getPublishedPostStaticPaths();
+  } catch (error) {
+    if (error instanceof PublishedContentConfigError) {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+const { slug } = Astro.params;
+const post = slug ? await getPublishedPostBySlug(slug) : null;
+
+if (!post) {
+  return Astro.redirect('/writing', 302);
+}
+
+const publishedDate = new Intl.DateTimeFormat('en', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+}).format(new Date(post.publishedAt));
+---
+
+<BaseLayout title={`${post.title} | Dhafin`} description={post.excerpt}>
+  <article class="section" aria-labelledby="post-title">
+    <header class="editorial-hero">
+      <div class="section">
+        <p class="eyebrow">{post.category.title} / {publishedDate}</p>
+        <h1 id="post-title" class="display">{post.title}</h1>
+        <p class="body-copy">{post.excerpt}</p>
+      </div>
+      {
+        post.coverImage ? (
+          <figure class="rich-figure">
+            <img
+              src={post.coverImage.asset.url}
+              alt={post.coverImage.alt}
+              width={post.coverImage.asset.metadata?.dimensions?.width}
+              height={post.coverImage.asset.metadata?.dimensions?.height}
+            />
+            {post.coverImage.caption && <figcaption>{post.coverImage.caption}</figcaption>}
+          </figure>
+        ) : (
+          <aside class="editorial-panel">
+            <p class="heading">Writing as product thinking.</p>
+            <p class="body-copy">
+              Build logs, creative process, and personal lessons stay in one feed so the site
+              stays coherent before it gets comprehensive.
+            </p>
+          </aside>
+        )
+      }
+    </header>
+
+    <RichText body={post.body} />
+  </article>
+</BaseLayout>

--- a/src/sanity/published/queries.ts
+++ b/src/sanity/published/queries.ts
@@ -14,6 +14,50 @@ export const imageProjection = `{
   }
 }`;
 
+export const bodyProjection = `[]{
+  ...,
+  _type == "imageBlock" => {
+    ...,
+    asset->{
+      _id,
+      url,
+      mimeType,
+      metadata {
+        dimensions {
+          width,
+          height
+        }
+      }
+    }
+  },
+  _type == "gallery" => {
+    ...,
+    images[] {
+      ...,
+      asset->{
+        _id,
+        url,
+        mimeType,
+        metadata {
+          dimensions {
+            width,
+            height
+          }
+        }
+      }
+    }
+  },
+  _type == "workReference" => {
+    ...,
+    work->{
+      _id,
+      title,
+      "slug": slug.current,
+      summary
+    }
+  }
+}`;
+
 export const categoryProjection = `{
   _id,
   title,
@@ -50,7 +94,7 @@ export const workProjection = `{
   gallery[] ${imageProjection},
   liveUrl,
   repoUrl,
-  body,
+  body ${bodyProjection},
   featured,
   sortOrder
 }`;
@@ -76,7 +120,7 @@ export const postProjection = `{
   publishedAt,
   updatedAt,
   coverImage ${imageProjection},
-  body,
+  body ${bodyProjection},
   relatedWork[]->{
     _id,
     title,

--- a/src/sanity/schema/blocks.ts
+++ b/src/sanity/schema/blocks.ts
@@ -139,6 +139,106 @@ export const bodyBlocks = defineField({
         },
       },
     }),
+    defineArrayMember({
+      name: 'callout',
+      title: 'Callout',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'tone',
+          title: 'Tone',
+          type: 'string',
+          options: {
+            list: [
+              { title: 'Note', value: 'note' },
+              { title: 'Product', value: 'product' },
+              { title: 'Warning', value: 'warning' },
+            ],
+          },
+          initialValue: 'note',
+          validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+          name: 'title',
+          title: 'Title',
+          type: 'string',
+        }),
+        defineField({
+          name: 'text',
+          title: 'Text',
+          type: 'text',
+          rows: 3,
+          validation: (Rule) => Rule.required(),
+        }),
+      ],
+    }),
+    defineArrayMember({
+      name: 'codeBlock',
+      title: 'Code block',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'filename',
+          title: 'Filename',
+          type: 'string',
+        }),
+        defineField({
+          name: 'language',
+          title: 'Language',
+          type: 'string',
+        }),
+        defineField({
+          name: 'code',
+          title: 'Code',
+          type: 'text',
+          rows: 12,
+          validation: (Rule) => Rule.required(),
+        }),
+      ],
+      preview: {
+        select: {
+          filename: 'filename',
+          language: 'language',
+        },
+        prepare({ filename, language }) {
+          return {
+            title: filename || 'Code block',
+            subtitle: language,
+          };
+        },
+      },
+    }),
+    defineArrayMember({
+      name: 'workReference',
+      title: 'Work reference',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'work',
+          title: 'Work',
+          type: 'reference',
+          to: [{ type: 'work' }],
+          validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+          name: 'label',
+          title: 'Label',
+          type: 'string',
+        }),
+      ],
+      preview: {
+        select: {
+          title: 'work.title',
+          subtitle: 'label',
+        },
+        prepare({ title, subtitle }) {
+          return {
+            title: title || 'Work reference',
+            subtitle,
+          };
+        },
+      },
+    }),
   ],
   validation: (Rule) => Rule.required().min(1),
 });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -487,6 +487,156 @@ button {
   background-size: 100% 10px;
 }
 
+@utility rich-text {
+  display: grid;
+  gap: var(--spacing-20);
+  max-width: 760px;
+}
+
+.rich-text > p,
+.rich-list,
+.rich-quote,
+.rich-callout p {
+  margin: 0;
+  color: var(--color-black-ink);
+  font-family: var(--font-bradford);
+  font-size: var(--text-body);
+  line-height: 1.7;
+  letter-spacing: var(--tracking-body);
+}
+
+@utility rich-heading {
+  margin: var(--spacing-20) 0 0;
+  font-family: var(--font-labilvariable);
+  font-size: var(--text-heading);
+  font-weight: 400;
+  line-height: var(--leading-heading);
+  letter-spacing: var(--tracking-heading);
+}
+
+@utility rich-subheading {
+  margin: var(--spacing-10) 0 0;
+  font-family: var(--font-labil);
+  font-size: var(--text-body);
+  font-weight: 500;
+  line-height: var(--leading-body);
+  letter-spacing: var(--tracking-meta);
+  text-transform: uppercase;
+}
+
+@utility rich-list {
+  display: grid;
+  gap: var(--spacing-8);
+  padding-left: var(--spacing-20);
+}
+
+@utility rich-quote {
+  border-left: 4px solid var(--color-electric-purple);
+  padding-left: var(--spacing-20);
+  color: var(--color-medium-gray);
+  font-size: 1.25rem;
+}
+
+@utility rich-figure {
+  display: grid;
+  gap: var(--spacing-8);
+  margin: var(--spacing-20) 0;
+}
+
+.rich-figure img,
+.rich-gallery img {
+  width: 100%;
+  border: var(--border-ink);
+  object-fit: cover;
+}
+
+.rich-figure figcaption,
+.rich-gallery figcaption,
+.rich-video figcaption,
+.rich-code figcaption {
+  color: var(--color-medium-gray);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+@utility rich-gallery {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-10);
+}
+
+.rich-gallery figure {
+  display: grid;
+  gap: var(--spacing-8);
+  margin: 0;
+}
+
+@utility rich-video {
+  display: grid;
+  gap: var(--spacing-8);
+  margin: var(--spacing-20) 0;
+}
+
+.rich-video iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: var(--border-ink);
+}
+
+@utility rich-callout {
+  display: grid;
+  gap: var(--spacing-8);
+  border: var(--border-ink);
+  padding: var(--spacing-20);
+  background: var(--color-muted-taupe);
+}
+
+@utility rich-callout-product {
+  background: var(--color-sunshine-yellow);
+}
+
+@utility rich-callout-warning {
+  background: var(--color-frost-gray);
+}
+
+@utility rich-callout-title {
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-caption);
+  text-transform: uppercase;
+}
+
+@utility rich-code {
+  display: grid;
+  gap: var(--spacing-8);
+  margin: var(--spacing-20) 0;
+}
+
+.rich-code pre {
+  overflow-x: auto;
+  margin: 0;
+  border: var(--border-ink);
+  padding: var(--spacing-16);
+  background: var(--color-black-ink);
+  color: var(--color-pure-white);
+}
+
+.rich-code code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+}
+
+@utility rich-work-reference {
+  display: grid;
+  gap: var(--spacing-10);
+  border: var(--border-ink);
+  padding: var(--spacing-20);
+  background: var(--color-pure-white);
+}
+
 @media (max-width: 760px) {
   .page-shell {
     width: min(100% - 1.5rem, var(--page-max-width));


### PR DESCRIPTION
Closes #6

What changed
- Built `/writing` from published Sanity posts with a planned-content fallback when Sanity env is missing.
- Added `/writing/[slug]` static routes for published posts.
- Added a rich content renderer for Portable Text blocks: headings, lists, links, images, galleries, YouTube embeds, callouts, code blocks, quotes, and work references.
- Expanded Sanity body schema and published projections for those rich blocks.

Validation
- [x] `bun run build`