### PR TITLE
Build Work section as primary proof

### DIFF
--- a/src/components/WorkCard.astro
+++ b/src/components/WorkCard.astro
@@ -1,0 +1,85 @@
+---
+import type { PublishedWorkStatus, SanityImage } from '../sanity/published';
+
+import Tag from './Tag.astro';
+
+interface Props {
+  coverImage?: SanityImage;
+  href: string;
+  liveUrl?: string;
+  mark?: string;
+  primaryActionLabel?: string;
+  proofTags: string[];
+  repoUrl?: string;
+  role: string;
+  stack?: string[];
+  status: PublishedWorkStatus;
+  summary: string;
+  title: string;
+  tone?: string;
+}
+
+const {
+  coverImage,
+  href,
+  liveUrl,
+  mark = '01',
+  primaryActionLabel = 'Read proof',
+  proofTags,
+  repoUrl,
+  role,
+  stack = [],
+  status,
+  summary,
+  title,
+  tone = 'var(--color-muted-taupe)',
+} = Astro.props;
+
+const dimensions = coverImage?.asset.metadata?.dimensions;
+const statusLabel =
+  {
+    live: 'Live product',
+    ongoing: 'Ongoing build',
+    paused: 'Paused',
+  }[status] ?? status;
+---
+
+<article class="work-card">
+  <a class="work-card-media" href={href} aria-label={title} style={`--media-tone: ${tone};`}>
+    {
+      coverImage ? (
+        <img
+          src={coverImage.asset.url}
+          alt={coverImage.alt}
+          width={dimensions?.width}
+          height={dimensions?.height}
+          loading="lazy"
+        />
+      ) : (
+        <span class="work-card-mark">{mark}</span>
+      )
+    }
+  </a>
+  <div class="work-card-content">
+    <div class="card-meta">
+      <Tag>{statusLabel}</Tag>
+      {proofTags.map((tag) => <Tag outline>{tag}</Tag>)}
+    </div>
+    <p class="eyebrow">{role}</p>
+    <h3 class="heading"><a class="card-link" href={href}>{title}</a></h3>
+    <p class="body-copy">{summary}</p>
+    {
+      stack.length > 0 && (
+        <p class="work-card-stack">
+          <span>Stack</span>
+          {stack.slice(0, 5).join(' / ')}
+        </p>
+      )
+    }
+    <div class="work-card-actions">
+      <a class="button" href={href}>{primaryActionLabel}</a>
+      {liveUrl && <a class="button" href={liveUrl} target="_blank" rel="noreferrer">Live</a>}
+      {repoUrl && <a class="button" href={repoUrl} target="_blank" rel="noreferrer">Repo</a>}
+    </div>
+  </div>
+</article>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -1,6 +1,82 @@
 ---
-import ArticleCard from '../components/ArticleCard.astro';
+import WorkCard from '../components/WorkCard.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { PublishedContentConfigError, getPublishedWorks } from '../sanity/published';
+import type { PublishedWork, PublishedWorkStatus, SanityImage } from '../sanity/published';
+
+type WorkListItem = Pick<
+  PublishedWork,
+  'liveUrl' | 'proofTags' | 'repoUrl' | 'role' | 'slug' | 'stack' | 'status' | 'summary' | 'title'
+> & {
+  coverImage?: SanityImage;
+};
+
+const fallbackWorks: WorkListItem[] = [
+  {
+    title: 'Invitasi',
+    slug: 'invitasi',
+    summary:
+      'Wedding invitation platform for couples and organizers to publish invitations, manage RSVPs, and grow into planning workflows.',
+    status: 'ongoing',
+    role: 'Product builder / design engineer',
+    proofTags: ['Onboarding', 'RSVP', 'Builder'],
+    stack: ['Next.js', 'TypeScript', 'Postgres'],
+    liveUrl: 'https://invitasi.app',
+  },
+  {
+    title: 'Devault',
+    slug: 'devault',
+    summary:
+      'Community SaaS for Discord teams to save useful resources from chat and monitor high-signal channels.',
+    status: 'live',
+    role: 'Product builder / UI systems',
+    proofTags: ['Community workflow', 'Dashboard'],
+    stack: ['Next.js', 'TanStack', 'Postgres'],
+    liveUrl: 'https://devault.app',
+  },
+  {
+    title: 'Standout Headshot',
+    slug: 'standout-headshot',
+    summary:
+      'AI image product for job seekers and companies to generate professional headshots with fast comprehension and conversion.',
+    status: 'live',
+    role: 'Creative technologist / product builder',
+    proofTags: ['AI images', 'Conversion'],
+    stack: ['Next.js', 'AI workflow', 'Cloudflare'],
+    liveUrl: 'https://standoutheadshot.com',
+  },
+];
+
+let works: PublishedWork[] = [];
+
+try {
+  works = await getPublishedWorks();
+} catch (error) {
+  if (!(error instanceof PublishedContentConfigError)) {
+    throw error;
+  }
+}
+
+const selectedWorks: WorkListItem[] = works.length > 0 ? works : fallbackWorks;
+const hasPublishedWorks = works.length > 0;
+
+function workTone(index: number): string {
+  return ['var(--color-sunshine-yellow)', 'var(--color-frost-gray)', 'var(--color-electric-purple)'][index % 3];
+}
+
+function workMark(work: WorkListItem, index: number): string {
+  return work.title.charAt(0).toUpperCase() || (index + 1).toString();
+}
+
+function toStatusLabel(status: PublishedWorkStatus): string {
+  return (
+    {
+      live: 'live',
+      ongoing: 'ongoing',
+      paused: 'paused',
+    }[status] ?? status
+  );
+}
 ---
 
 <BaseLayout title="Work | Dhafin" description="Selected product-building work by Dhafin.">
@@ -14,34 +90,26 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </section>
 
   <section class="section section-taupe" aria-label="Selected product cards">
-    <div class="grid-three">
-      <ArticleCard
-        title="Invitasi"
-        eyebrow="Ongoing SaaS"
-        summary="Wedding invitation platform for couples and organizers to publish invitations, manage RSVPs, and grow into planning workflows."
-        tags={['Onboarding', 'RSVP', 'Builder']}
-        href="/work/invitasi"
-        tone="var(--color-sunshine-yellow)"
-        mark="I"
-      />
-      <ArticleCard
-        title="Devault"
-        eyebrow="Live product"
-        summary="Community SaaS for Discord teams to save useful resources from chat and monitor high-signal channels."
-        tags={['Community workflow', 'Dashboard']}
-        href="/work/devault"
-        tone="var(--color-frost-gray)"
-        mark="D"
-      />
-      <ArticleCard
-        title="Standout Headshot"
-        eyebrow="AI product"
-        summary="Professional headshot generation product shaped around fast comprehension and conversion."
-        tags={['AI images', 'Conversion']}
-        href="/work/standout-headshot"
-        tone="var(--color-electric-purple)"
-        mark="S"
-      />
+    <div class="work-list">
+      {
+        selectedWorks.map((work, index) => (
+          <WorkCard
+            title={work.title}
+            summary={work.summary}
+            role={`${work.role} / ${toStatusLabel(work.status)}`}
+            proofTags={work.proofTags}
+            stack={work.stack}
+            status={work.status}
+            href={hasPublishedWorks ? `/work/${work.slug}` : work.liveUrl}
+            liveUrl={hasPublishedWorks ? work.liveUrl : undefined}
+            repoUrl={work.repoUrl}
+            coverImage={work.coverImage}
+            tone={workTone(index)}
+            mark={workMark(work, index)}
+            primaryActionLabel={hasPublishedWorks ? 'Read proof' : 'Open live'}
+          />
+        ))
+      }
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -1,0 +1,117 @@
+---
+import RichText from '../../components/RichText.astro';
+import Tag from '../../components/Tag.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import {
+  PublishedContentConfigError,
+  getPublishedWorkBySlug,
+  getPublishedWorkStaticPaths,
+} from '../../sanity/published';
+import type { PublishedWorkStatus } from '../../sanity/published';
+
+export async function getStaticPaths() {
+  try {
+    return await getPublishedWorkStaticPaths();
+  } catch (error) {
+    if (error instanceof PublishedContentConfigError) {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+const { slug } = Astro.params;
+const work = slug ? await getPublishedWorkBySlug(slug) : null;
+
+if (!work) {
+  return Astro.redirect('/work', 302);
+}
+
+const coverDimensions = work.coverImage.asset.metadata?.dimensions;
+const statusLabel =
+  {
+    live: 'Live product',
+    ongoing: 'Ongoing build',
+    paused: 'Paused',
+  }[work.status as PublishedWorkStatus] ?? work.status;
+---
+
+<BaseLayout title={`${work.title} | Dhafin`} description={work.summary}>
+  <article class="section" aria-labelledby="work-title">
+    <header class="editorial-hero">
+      <div class="section">
+        <p class="eyebrow">Selected work / {statusLabel}</p>
+        <h1 id="work-title" class="display">{work.title}</h1>
+        <p class="body-copy">{work.summary}</p>
+        <div class="work-link-row">
+          <a class="button button-highlight" href={work.liveUrl} target="_blank" rel="noreferrer">Open live</a>
+          {work.repoUrl && <a class="button" href={work.repoUrl} target="_blank" rel="noreferrer">Repository</a>}
+        </div>
+      </div>
+      <figure class="work-hero-media">
+        <img
+          src={work.coverImage.asset.url}
+          alt={work.coverImage.alt}
+          width={coverDimensions?.width}
+          height={coverDimensions?.height}
+        />
+        {work.coverImage.caption && <figcaption>{work.coverImage.caption}</figcaption>}
+      </figure>
+    </header>
+
+    <section class="work-proof-grid" aria-label="Product proof">
+      <div class="work-proof-panel">
+        <p class="eyebrow">Role</p>
+        <p class="body-copy">{work.role}</p>
+      </div>
+      <div class="work-proof-panel">
+        <p class="eyebrow">Proof</p>
+        <div class="card-meta">
+          {work.proofTags.map((tag) => <Tag outline>{tag}</Tag>)}
+        </div>
+      </div>
+      {
+        work.stack.length > 0 && (
+          <div class="work-proof-panel">
+            <p class="eyebrow">Stack, secondary</p>
+            <p class="body-copy">{work.stack.join(' / ')}</p>
+          </div>
+        )
+      }
+    </section>
+
+    {
+      work.gallery.length > 0 && (
+        <section class="section" aria-labelledby="work-gallery-title">
+          <p class="eyebrow">Screenshots</p>
+          <h2 id="work-gallery-title" class="heading">The interface does the proof.</h2>
+          <div class="work-gallery">
+            {work.gallery.map((image) => {
+              const dimensions = image.asset.metadata?.dimensions;
+
+              return (
+                <figure>
+                  <img
+                    src={image.asset.url}
+                    alt={image.alt}
+                    width={dimensions?.width}
+                    height={dimensions?.height}
+                    loading="lazy"
+                  />
+                  {image.caption && <figcaption>{image.caption}</figcaption>}
+                </figure>
+              );
+            })}
+          </div>
+        </section>
+      )
+    }
+
+    <section class="section" aria-labelledby="work-note-title">
+      <p class="eyebrow">Build note</p>
+      <h2 id="work-note-title" class="heading">What mattered in the product.</h2>
+      <RichText body={work.body} />
+    </section>
+  </article>
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -380,6 +380,134 @@ button {
   text-decoration: none;
 }
 
+@utility work-list {
+  display: grid;
+  gap: var(--spacing-40);
+}
+
+@utility work-card {
+  display: grid;
+  grid-template-columns: minmax(16rem, 5fr) minmax(0, 7fr);
+  gap: var(--spacing-20);
+  border: var(--border-ink);
+  background: var(--color-pure-white);
+}
+
+@utility work-card-media {
+  position: relative;
+  min-height: 20rem;
+  overflow: hidden;
+  background:
+    linear-gradient(135deg, transparent 0 48%, rgb(43 43 43 / 100%) 48% 52%, transparent 52%),
+    var(--media-tone, var(--color-muted-taupe));
+}
+
+.work-card-media img,
+.work-hero-media img,
+.work-gallery img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+@utility work-card-mark {
+  position: absolute;
+  right: var(--spacing-20);
+  bottom: var(--spacing-16);
+  color: var(--color-black-ink);
+  font-family: var(--font-labilvariable);
+  font-size: clamp(4rem, 18vw, 10rem);
+  line-height: 0.85;
+  letter-spacing: var(--tracking-display);
+}
+
+@utility work-card-content {
+  display: grid;
+  align-content: start;
+  gap: var(--spacing-12);
+  padding: var(--spacing-20);
+}
+
+@utility work-card-stack {
+  margin: var(--spacing-8) 0 0;
+  color: var(--color-medium-gray);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+.work-card-stack span {
+  margin-right: var(--spacing-8);
+  color: var(--color-black-ink);
+  text-transform: uppercase;
+}
+
+@utility work-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-8);
+  margin-top: var(--spacing-8);
+}
+
+@utility work-link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-10);
+}
+
+@utility work-hero-media {
+  display: grid;
+  gap: var(--spacing-8);
+  align-self: stretch;
+  margin: 0;
+  border: var(--border-ink);
+  background: var(--color-frost-gray);
+}
+
+.work-hero-media figcaption,
+.work-gallery figcaption {
+  color: var(--color-medium-gray);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+@utility work-proof-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: var(--border-ink);
+  border-bottom: var(--border-ink);
+}
+
+@utility work-proof-panel {
+  display: grid;
+  align-content: start;
+  gap: var(--spacing-10);
+  padding: var(--spacing-20);
+}
+
+.work-proof-panel + .work-proof-panel {
+  border-left: var(--border-ink);
+}
+
+@utility work-gallery {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--spacing-10);
+}
+
+.work-gallery figure {
+  display: grid;
+  gap: var(--spacing-8);
+  margin: 0;
+}
+
+.work-gallery img {
+  border: var(--border-ink);
+}
+
 @utility section {
   display: grid;
   gap: var(--spacing-20);
@@ -660,8 +788,16 @@ button {
 
   .editorial-hero,
   .grid-three,
+  .work-card,
+  .work-gallery,
+  .work-proof-grid,
   .rule-item {
     grid-template-columns: 1fr;
+  }
+
+  .work-proof-panel + .work-proof-panel {
+    border-top: var(--border-ink);
+    border-left: 0;
   }
 
   .editorial-hero {


### PR DESCRIPTION
Closes #7

What changed
- Replaced static `/work` cards with Sanity-backed selected work sorted by `sortOrder`, with a safe product fallback when Sanity env is missing.
- Added a Work-specific card focused on outcome, role, proof tags, screenshots, and relevant links.
- Added `/work/[slug]` detail pages rendering cover image, role/proof/stack metadata, gallery screenshots, and rich build notes.
- Kept stack metadata secondary to product proof.

Validation
- [x] `bun run build`