### PR TITLE
Add Sanity image media handling

### DIFF
--- a/src/components/RichText.astro
+++ b/src/components/RichText.astro
@@ -1,6 +1,8 @@
 ---
 import type { PortableTextBody, SanityImage } from '../sanity/published';
 
+import SanityImageView from './SanityImage.astro';
+
 interface Props {
   body: PortableTextBody;
 }
@@ -205,17 +207,10 @@ const nodes = toNodes(body);
 
       if (node._type === 'imageBlock') {
         const image = node as SanityImage;
-        const dimensions = image.asset?.metadata?.dimensions;
 
         return (
           <figure class="rich-figure">
-            <img
-              src={image.asset.url}
-              alt={image.alt}
-              width={dimensions?.width}
-              height={dimensions?.height}
-              loading="lazy"
-            />
+            <SanityImageView image={image} sizes="(max-width: 760px) 100vw, 760px" />
             {image.caption && <figcaption>{image.caption}</figcaption>}
           </figure>
         );
@@ -227,17 +222,9 @@ const nodes = toNodes(body);
         return (
           <div class="rich-gallery">
             {(gallery.images ?? []).map((image) => {
-              const dimensions = image.asset?.metadata?.dimensions;
-
               return (
                 <figure>
-                  <img
-                    src={image.asset.url}
-                    alt={image.alt}
-                    width={dimensions?.width}
-                    height={dimensions?.height}
-                    loading="lazy"
-                  />
+                  <SanityImageView image={image} sizes="(max-width: 760px) 100vw, 380px" widths={[360, 540, 720, 960]} />
                   {image.caption && <figcaption>{image.caption}</figcaption>}
                 </figure>
               );

--- a/src/components/SanityImage.astro
+++ b/src/components/SanityImage.astro
@@ -1,0 +1,53 @@
+---
+import { getSanityImageSrcSet, getSanityImageUrl, type SanityImageFit } from '../sanity/published/image';
+import type { SanityImage } from '../sanity/published';
+
+interface Props {
+  class?: string;
+  fetchpriority?: 'auto' | 'high' | 'low';
+  fit?: SanityImageFit;
+  height?: number;
+  image: SanityImage;
+  loading?: 'eager' | 'lazy';
+  quality?: number;
+  sizes?: string;
+  width?: number;
+  widths?: number[];
+}
+
+const {
+  class: className,
+  fetchpriority,
+  fit = 'max',
+  height,
+  image,
+  loading = 'lazy',
+  quality = 82,
+  sizes = '(max-width: 760px) 100vw, 760px',
+  width,
+  widths = [480, 720, 960, 1200, 1600],
+} = Astro.props;
+
+const dimensions = image.asset.metadata?.dimensions;
+const maxResponsiveWidth = Math.max(...widths);
+const fallbackWidth = width ?? Math.min(dimensions?.width ?? maxResponsiveWidth, maxResponsiveWidth);
+const fallbackHeight =
+  height ?? (width && dimensions ? Math.round((width / dimensions.width) * dimensions.height) : undefined);
+const renderedWidth = width ?? dimensions?.width ?? fallbackWidth;
+const renderedHeight = height ?? dimensions?.height ?? fallbackHeight;
+const src = getSanityImageUrl(image, { fit, height: fallbackHeight, quality, width: fallbackWidth });
+const srcset = getSanityImageSrcSet(image, widths, { fit, height, quality, width });
+---
+
+<img
+  class={className}
+  src={src}
+  srcset={srcset}
+  sizes={sizes}
+  alt={image.alt}
+  width={renderedWidth}
+  height={renderedHeight}
+  loading={loading}
+  decoding="async"
+  fetchpriority={fetchpriority}
+/>

--- a/src/components/WorkCard.astro
+++ b/src/components/WorkCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { PublishedWorkStatus, SanityImage } from '../sanity/published';
 
+import SanityImageView from './SanityImage.astro';
 import Tag from './Tag.astro';
 
 interface Props {
@@ -35,7 +36,6 @@ const {
   tone = 'var(--color-muted-taupe)',
 } = Astro.props;
 
-const dimensions = coverImage?.asset.metadata?.dimensions;
 const statusLabel =
   {
     live: 'Live product',
@@ -48,13 +48,7 @@ const statusLabel =
   <a class="work-card-media" href={href} aria-label={title} style={`--media-tone: ${tone};`}>
     {
       coverImage ? (
-        <img
-          src={coverImage.asset.url}
-          alt={coverImage.alt}
-          width={dimensions?.width}
-          height={dimensions?.height}
-          loading="lazy"
-        />
+        <SanityImageView image={coverImage} sizes="(max-width: 760px) 100vw, 38vw" widths={[480, 720, 960, 1200]} />
       ) : (
         <span class="work-card-mark">{mark}</span>
       )

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import RichText from '../../components/RichText.astro';
+import SanityImageView from '../../components/SanityImage.astro';
 import Tag from '../../components/Tag.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import {
@@ -28,7 +29,6 @@ if (!work) {
   return Astro.redirect('/work', 302);
 }
 
-const coverDimensions = work.coverImage.asset.metadata?.dimensions;
 const statusLabel =
   {
     live: 'Live product',
@@ -50,11 +50,12 @@ const statusLabel =
         </div>
       </div>
       <figure class="work-hero-media">
-        <img
-          src={work.coverImage.asset.url}
-          alt={work.coverImage.alt}
-          width={coverDimensions?.width}
-          height={coverDimensions?.height}
+        <SanityImageView
+          image={work.coverImage}
+          loading="eager"
+          fetchpriority="high"
+          sizes="(max-width: 760px) 100vw, 42vw"
+          widths={[720, 960, 1200, 1600, 2000]}
         />
         {work.coverImage.caption && <figcaption>{work.coverImage.caption}</figcaption>}
       </figure>
@@ -88,17 +89,9 @@ const statusLabel =
           <h2 id="work-gallery-title" class="heading">The interface does the proof.</h2>
           <div class="work-gallery">
             {work.gallery.map((image) => {
-              const dimensions = image.asset.metadata?.dimensions;
-
               return (
                 <figure>
-                  <img
-                    src={image.asset.url}
-                    alt={image.alt}
-                    width={dimensions?.width}
-                    height={dimensions?.height}
-                    loading="lazy"
-                  />
+                  <SanityImageView image={image} sizes="(max-width: 760px) 100vw, 50vw" />
                   {image.caption && <figcaption>{image.caption}</figcaption>}
                 </figure>
               );

--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import RichText from '../../components/RichText.astro';
+import SanityImageView from '../../components/SanityImage.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import {
   PublishedContentConfigError,
@@ -44,11 +45,12 @@ const publishedDate = new Intl.DateTimeFormat('en', {
       {
         post.coverImage ? (
           <figure class="rich-figure">
-            <img
-              src={post.coverImage.asset.url}
-              alt={post.coverImage.alt}
-              width={post.coverImage.asset.metadata?.dimensions?.width}
-              height={post.coverImage.asset.metadata?.dimensions?.height}
+            <SanityImageView
+              image={post.coverImage}
+              loading="eager"
+              fetchpriority="high"
+              sizes="(max-width: 760px) 100vw, 42vw"
+              widths={[720, 960, 1200, 1600, 2000]}
             />
             {post.coverImage.caption && <figcaption>{post.coverImage.caption}</figcaption>}
           </figure>

--- a/src/sanity/published/image.ts
+++ b/src/sanity/published/image.ts
@@ -1,0 +1,56 @@
+import type { SanityImage } from './types';
+
+export type SanityImageFit = 'clip' | 'crop' | 'fill' | 'fillmax' | 'max' | 'scale';
+
+export type SanityImageUrlOptions = {
+  fit?: SanityImageFit;
+  height?: number;
+  quality?: number;
+  width?: number;
+};
+
+function toPositiveInteger(value: number | undefined): string | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+
+  return Math.round(value).toString();
+}
+
+export function getSanityImageUrl(image: SanityImage, options: SanityImageUrlOptions = {}): string {
+  const url = new URL(image.asset.url);
+  const width = toPositiveInteger(options.width);
+  const height = toPositiveInteger(options.height);
+
+  url.searchParams.set('auto', 'format');
+  url.searchParams.set('fit', options.fit ?? 'max');
+  url.searchParams.set('q', toPositiveInteger(options.quality) ?? '82');
+
+  if (width) {
+    url.searchParams.set('w', width);
+  }
+
+  if (height) {
+    url.searchParams.set('h', height);
+  }
+
+  return url.toString();
+}
+
+export function getSanityImageSrcSet(
+  image: SanityImage,
+  widths: number[],
+  options: SanityImageUrlOptions = {},
+): string {
+  return widths
+    .filter((width) => Number.isFinite(width) && width > 0)
+    .map((width) => {
+      const height =
+        options.height && options.width
+          ? Math.round((width / options.width) * options.height)
+          : undefined;
+
+      return `${getSanityImageUrl(image, { ...options, height, width })} ${Math.round(width)}w`;
+    })
+    .join(', ');
+}


### PR DESCRIPTION
Closes #9

What changed
- Added a reusable Sanity image URL helper that appends CDN transform params (`auto=format`, width, fit, quality).
- Added a reusable `SanityImage` component with responsive `srcset`, `sizes`, explicit dimensions, lazy/eager loading controls, and async decoding.
- Replaced raw Sanity image URLs across Work cards, Work detail cover/gallery images, Writing cover images, and rich body image/gallery blocks.
- Kept YouTube embeds on `youtube-nocookie` inside rich content.
- No CMS-authored screenshots or large media files were committed to the repository.

Validation
- [x] `bun run build`