### PR TITLE
Implement authenticated draft preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 PUBLIC_SITE_URL=https://dhaf.in
 ASTRO_TELEMETRY_DISABLED=1
 
-# Preview auth values will be required by a later issue.
+# Draft preview auth. Keep both server-only.
 PREVIEW_SECRET=
 SANITY_READ_TOKEN=
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@sanity/client": "^7.13.2",
         "@tailwindcss/vite": "^4.2.4",
         "astro": "^5.16.4",
+        "jose": "^6.2.3",
         "sanity": "^4.22.0",
         "styled-components": "^6.1.15",
         "tailwindcss": "^4.2.4",
@@ -1519,6 +1520,8 @@
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@sanity/client": "^7.13.2",
     "@tailwindcss/vite": "^4.2.4",
     "astro": "^5.16.4",
+    "jose": "^6.2.3",
     "sanity": "^4.22.0",
     "styled-components": "^6.1.15",
     "tailwindcss": "^4.2.4"

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,0 +1,77 @@
+import type { APIRoute } from 'astro';
+
+import {
+  PREVIEW_COOKIE_NAME,
+  PREVIEW_MAX_AGE_SECONDS,
+  PreviewContentConfigError,
+  createPreviewToken,
+  getAstroRuntimeEnv,
+  getPreviewSanityEnv,
+  type PreviewContentType,
+} from '../../sanity/preview';
+
+export const prerender = false;
+
+function normalizeType(value: string | null): PreviewContentType | null {
+  if (value === 'work') {
+    return 'work';
+  }
+
+  if (value === 'post' || value === 'writing') {
+    return 'writing';
+  }
+
+  return null;
+}
+
+function safeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  let mismatch = 0;
+
+  for (let index = 0; index < left.length; index += 1) {
+    mismatch |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+
+  return mismatch === 0;
+}
+
+export const GET: APIRoute = async ({ cookies, locals, redirect, request }) => {
+  const runtimeEnv = getAstroRuntimeEnv(locals);
+  const url = new URL(request.url);
+  const secret = url.searchParams.get('secret');
+  const slug = url.searchParams.get('slug');
+  const type = normalizeType(url.searchParams.get('type'));
+
+  if (!secret || !slug || !type) {
+    return new Response('Missing preview secret, slug, or type.', { status: 400 });
+  }
+
+  try {
+    const { previewSecret } = getPreviewSanityEnv(runtimeEnv);
+
+    if (!safeEqual(secret, previewSecret)) {
+      return new Response('Invalid preview secret.', { status: 401 });
+    }
+
+    const token = await createPreviewToken({ slug, type }, runtimeEnv);
+
+    cookies.set(PREVIEW_COOKIE_NAME, token, {
+      httpOnly: true,
+      maxAge: PREVIEW_MAX_AGE_SECONDS,
+      path: '/preview',
+      sameSite: 'lax',
+      secure: true,
+    });
+
+    return redirect(`/preview/${type}/${encodeURIComponent(slug)}`, 307);
+  } catch (error) {
+    if (error instanceof PreviewContentConfigError) {
+      return new Response(error.message, { status: 500 });
+    }
+
+    throw error;
+  }
+};

--- a/src/pages/preview/work/[slug].astro
+++ b/src/pages/preview/work/[slug].astro
@@ -1,0 +1,122 @@
+---
+import RichText from '../../../components/RichText.astro';
+import SanityImageView from '../../../components/SanityImage.astro';
+import Tag from '../../../components/Tag.astro';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import {
+  PREVIEW_COOKIE_NAME,
+  PreviewContentConfigError,
+  getAstroRuntimeEnv,
+  getPreviewWorkBySlug,
+  isPreviewAuthorized,
+} from '../../../sanity/preview';
+import type { PublishedWorkStatus } from '../../../sanity/published';
+
+export const prerender = false;
+
+const { slug } = Astro.params;
+
+if (!slug) {
+  return new Response('Missing preview slug.', { status: 400 });
+}
+
+const runtimeEnv = getAstroRuntimeEnv(Astro.locals);
+const previewCookie = Astro.cookies.get(PREVIEW_COOKIE_NAME)?.value;
+
+try {
+  const authorized = await isPreviewAuthorized(previewCookie, 'work', slug, runtimeEnv);
+
+  if (!authorized) {
+    return new Response('Preview authorization required.', { status: 401 });
+  }
+} catch (error) {
+  if (error instanceof PreviewContentConfigError) {
+    return new Response(error.message, { status: 500 });
+  }
+
+  throw error;
+}
+
+const work = await getPreviewWorkBySlug(slug, runtimeEnv);
+
+if (!work) {
+  return new Response('Preview work document not found.', { status: 404 });
+}
+
+const statusLabel =
+  {
+    live: 'Live product',
+    ongoing: 'Ongoing build',
+    paused: 'Paused',
+  }[work.status as PublishedWorkStatus] ?? work.status;
+---
+
+<BaseLayout title={`Preview: ${work.title} | Dhafin`} description={work.summary}>
+  <article class="section" aria-labelledby="work-title">
+    <header class="editorial-hero">
+      <div class="section">
+        <p class="eyebrow">Draft preview / selected work / {statusLabel}</p>
+        <h1 id="work-title" class="display">{work.title}</h1>
+        <p class="body-copy">{work.summary}</p>
+        <div class="work-link-row">
+          <a class="button button-highlight" href={work.liveUrl} target="_blank" rel="noreferrer">Open live</a>
+          {work.repoUrl && <a class="button" href={work.repoUrl} target="_blank" rel="noreferrer">Repository</a>}
+        </div>
+      </div>
+      <figure class="work-hero-media">
+        <SanityImageView
+          image={work.coverImage}
+          loading="eager"
+          fetchpriority="high"
+          sizes="(max-width: 760px) 100vw, 42vw"
+          widths={[720, 960, 1200, 1600, 2000]}
+        />
+        {work.coverImage.caption && <figcaption>{work.coverImage.caption}</figcaption>}
+      </figure>
+    </header>
+
+    <section class="work-proof-grid" aria-label="Product proof">
+      <div class="work-proof-panel">
+        <p class="eyebrow">Role</p>
+        <p class="body-copy">{work.role}</p>
+      </div>
+      <div class="work-proof-panel">
+        <p class="eyebrow">Proof</p>
+        <div class="card-meta">
+          {work.proofTags.map((tag) => <Tag outline>{tag}</Tag>)}
+        </div>
+      </div>
+      {
+        work.stack.length > 0 && (
+          <div class="work-proof-panel">
+            <p class="eyebrow">Stack, secondary</p>
+            <p class="body-copy">{work.stack.join(' / ')}</p>
+          </div>
+        )
+      }
+    </section>
+
+    {
+      work.gallery.length > 0 && (
+        <section class="section" aria-labelledby="work-gallery-title">
+          <p class="eyebrow">Screenshots</p>
+          <h2 id="work-gallery-title" class="heading">The interface does the proof.</h2>
+          <div class="work-gallery">
+            {work.gallery.map((image) => (
+              <figure>
+                <SanityImageView image={image} sizes="(max-width: 760px) 100vw, 50vw" />
+                {image.caption && <figcaption>{image.caption}</figcaption>}
+              </figure>
+            ))}
+          </div>
+        </section>
+      )
+    }
+
+    <section class="section" aria-labelledby="work-note-title">
+      <p class="eyebrow">Draft build note</p>
+      <h2 id="work-note-title" class="heading">What mattered in the product.</h2>
+      <RichText body={work.body} />
+    </section>
+  </article>
+</BaseLayout>

--- a/src/pages/preview/writing/[slug].astro
+++ b/src/pages/preview/writing/[slug].astro
@@ -1,0 +1,85 @@
+---
+import RichText from '../../../components/RichText.astro';
+import SanityImageView from '../../../components/SanityImage.astro';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+import {
+  PREVIEW_COOKIE_NAME,
+  PreviewContentConfigError,
+  getAstroRuntimeEnv,
+  getPreviewPostBySlug,
+  isPreviewAuthorized,
+} from '../../../sanity/preview';
+
+export const prerender = false;
+
+const { slug } = Astro.params;
+
+if (!slug) {
+  return new Response('Missing preview slug.', { status: 400 });
+}
+
+const runtimeEnv = getAstroRuntimeEnv(Astro.locals);
+const previewCookie = Astro.cookies.get(PREVIEW_COOKIE_NAME)?.value;
+
+try {
+  const authorized = await isPreviewAuthorized(previewCookie, 'writing', slug, runtimeEnv);
+
+  if (!authorized) {
+    return new Response('Preview authorization required.', { status: 401 });
+  }
+} catch (error) {
+  if (error instanceof PreviewContentConfigError) {
+    return new Response(error.message, { status: 500 });
+  }
+
+  throw error;
+}
+
+const post = await getPreviewPostBySlug(slug, runtimeEnv);
+
+if (!post) {
+  return new Response('Preview writing document not found.', { status: 404 });
+}
+
+const publishedDate = new Intl.DateTimeFormat('en', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric',
+}).format(new Date(post.publishedAt));
+---
+
+<BaseLayout title={`Preview: ${post.title} | Dhafin`} description={post.excerpt}>
+  <article class="section" aria-labelledby="post-title">
+    <header class="editorial-hero">
+      <div class="section">
+        <p class="eyebrow">Draft preview / {post.category.title} / {publishedDate}</p>
+        <h1 id="post-title" class="display">{post.title}</h1>
+        <p class="body-copy">{post.excerpt}</p>
+      </div>
+      {
+        post.coverImage ? (
+          <figure class="rich-figure">
+            <SanityImageView
+              image={post.coverImage}
+              loading="eager"
+              fetchpriority="high"
+              sizes="(max-width: 760px) 100vw, 42vw"
+              widths={[720, 960, 1200, 1600, 2000]}
+            />
+            {post.coverImage.caption && <figcaption>{post.coverImage.caption}</figcaption>}
+          </figure>
+        ) : (
+          <aside class="editorial-panel">
+            <p class="heading">Writing as product thinking.</p>
+            <p class="body-copy">
+              Build logs, creative process, and personal lessons stay in one feed so the site
+              stays coherent before it gets comprehensive.
+            </p>
+          </aside>
+        )
+      }
+    </header>
+
+    <RichText body={post.body} />
+  </article>
+</BaseLayout>

--- a/src/sanity/preview/auth.ts
+++ b/src/sanity/preview/auth.ts
@@ -1,0 +1,81 @@
+import { SignJWT, jwtVerify } from 'jose';
+
+import { getPreviewSanityEnv, type RuntimeEnv } from './env';
+
+export const PREVIEW_COOKIE_NAME = 'dhafin_preview';
+export const PREVIEW_MAX_AGE_SECONDS = 15 * 60;
+
+export type PreviewContentType = 'work' | 'writing';
+
+export type PreviewTokenPayload = {
+  scope: 'sanity-preview';
+  slug: string;
+  type: PreviewContentType;
+};
+
+const encoder = new TextEncoder();
+
+function getSigningKey(runtimeEnv?: RuntimeEnv): Uint8Array {
+  return encoder.encode(getPreviewSanityEnv(runtimeEnv).previewSecret);
+}
+
+function isPreviewContentType(value: unknown): value is PreviewContentType {
+  return value === 'work' || value === 'writing';
+}
+
+export async function createPreviewToken(
+  payload: Pick<PreviewTokenPayload, 'slug' | 'type'>,
+  runtimeEnv?: RuntimeEnv,
+): Promise<string> {
+  return new SignJWT({
+    scope: 'sanity-preview',
+    slug: payload.slug,
+    type: payload.type,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(`${PREVIEW_MAX_AGE_SECONDS}s`)
+    .sign(getSigningKey(runtimeEnv));
+}
+
+export async function verifyPreviewToken(
+  token: string | undefined,
+  runtimeEnv?: RuntimeEnv,
+): Promise<PreviewTokenPayload | null> {
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, getSigningKey(runtimeEnv), {
+      algorithms: ['HS256'],
+    });
+
+    if (
+      payload.scope !== 'sanity-preview' ||
+      typeof payload.slug !== 'string' ||
+      !isPreviewContentType(payload.type)
+    ) {
+      return null;
+    }
+
+    return {
+      scope: 'sanity-preview',
+      slug: payload.slug,
+      type: payload.type,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function isPreviewAuthorized(
+  token: string | undefined,
+  expectedType: PreviewContentType,
+  expectedSlug: string,
+  runtimeEnv?: RuntimeEnv,
+): Promise<boolean> {
+  const payload = await verifyPreviewToken(token, runtimeEnv);
+
+  return payload?.type === expectedType && payload.slug === expectedSlug;
+}

--- a/src/sanity/preview/client.ts
+++ b/src/sanity/preview/client.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@sanity/client';
+
+import { getPreviewSanityEnv, type RuntimeEnv } from './env';
+
+export function createPreviewSanityClient(runtimeEnv?: RuntimeEnv) {
+  const { apiVersion, dataset, projectId, readToken } = getPreviewSanityEnv(runtimeEnv);
+
+  return createClient({
+    apiVersion,
+    dataset,
+    perspective: 'drafts',
+    projectId,
+    token: readToken,
+    useCdn: false,
+  });
+}

--- a/src/sanity/preview/env.ts
+++ b/src/sanity/preview/env.ts
@@ -1,0 +1,53 @@
+export type RuntimeEnv = Record<string, string | undefined>;
+
+export type PreviewSanityEnv = {
+  apiVersion: string;
+  dataset: string;
+  previewSecret: string;
+  projectId: string;
+  readToken: string;
+};
+
+const DEFAULT_API_VERSION = '2025-02-19';
+const DEFAULT_DATASET = 'production';
+
+export class PreviewContentConfigError extends Error {
+  constructor(message: string) {
+    super(`Preview Sanity content is not configured: ${message}`);
+    this.name = 'PreviewContentConfigError';
+  }
+}
+
+function readEnv(name: string, runtimeEnv?: RuntimeEnv): string | undefined {
+  return runtimeEnv?.[name] ?? process.env[name];
+}
+
+function requiredEnv(name: string, runtimeEnv?: RuntimeEnv): string {
+  const value = readEnv(name, runtimeEnv);
+
+  if (!value) {
+    throw new PreviewContentConfigError(`Missing ${name}.`);
+  }
+
+  return value;
+}
+
+export function getAstroRuntimeEnv(locals: unknown): RuntimeEnv | undefined {
+  if (typeof locals !== 'object' || locals === null) {
+    return undefined;
+  }
+
+  const runtime = (locals as { runtime?: { env?: RuntimeEnv } }).runtime;
+
+  return runtime?.env;
+}
+
+export function getPreviewSanityEnv(runtimeEnv?: RuntimeEnv): PreviewSanityEnv {
+  return {
+    apiVersion: readEnv('SANITY_API_VERSION', runtimeEnv) ?? DEFAULT_API_VERSION,
+    dataset: readEnv('SANITY_STUDIO_DATASET', runtimeEnv) ?? DEFAULT_DATASET,
+    previewSecret: requiredEnv('PREVIEW_SECRET', runtimeEnv),
+    projectId: requiredEnv('SANITY_STUDIO_PROJECT_ID', runtimeEnv),
+    readToken: requiredEnv('SANITY_READ_TOKEN', runtimeEnv),
+  };
+}

--- a/src/sanity/preview/fetch.ts
+++ b/src/sanity/preview/fetch.ts
@@ -1,0 +1,19 @@
+import { validatePublishedPost, validatePublishedWork } from '../published/validation';
+import type { PublishedPost, PublishedWork } from '../published';
+import { createPreviewSanityClient } from './client';
+import { previewPostBySlugQuery, previewWorkBySlugQuery } from './queries';
+import type { RuntimeEnv } from './env';
+
+export async function getPreviewWorkBySlug(slug: string, runtimeEnv?: RuntimeEnv): Promise<PublishedWork | null> {
+  const client = createPreviewSanityClient(runtimeEnv);
+  const result = await client.fetch<unknown | null>(previewWorkBySlugQuery, { slug });
+
+  return result ? validatePublishedWork(result) : null;
+}
+
+export async function getPreviewPostBySlug(slug: string, runtimeEnv?: RuntimeEnv): Promise<PublishedPost | null> {
+  const client = createPreviewSanityClient(runtimeEnv);
+  const result = await client.fetch<unknown | null>(previewPostBySlugQuery, { slug });
+
+  return result ? validatePublishedPost(result) : null;
+}

--- a/src/sanity/preview/index.ts
+++ b/src/sanity/preview/index.ts
@@ -1,0 +1,11 @@
+export {
+  PREVIEW_COOKIE_NAME,
+  PREVIEW_MAX_AGE_SECONDS,
+  createPreviewToken,
+  isPreviewAuthorized,
+  verifyPreviewToken,
+} from './auth';
+export type { PreviewContentType, PreviewTokenPayload } from './auth';
+export { PreviewContentConfigError, getAstroRuntimeEnv, getPreviewSanityEnv } from './env';
+export type { PreviewSanityEnv, RuntimeEnv } from './env';
+export { getPreviewPostBySlug, getPreviewWorkBySlug } from './fetch';

--- a/src/sanity/preview/queries.ts
+++ b/src/sanity/preview/queries.ts
@@ -1,0 +1,11 @@
+import { postProjection, workProjection } from '../published/queries';
+
+export const previewWorkBySlugQuery = `*[
+  _type == "work" &&
+  slug.current == $slug
+][0] ${workProjection}`;
+
+export const previewPostBySlugQuery = `*[
+  _type == "post" &&
+  slug.current == $slug
+][0] ${postProjection}`;


### PR DESCRIPTION
Closes #10

What changed
- Added `jose` and server-only preview auth helpers for short-lived signed preview cookies.
- Added `/api/preview` to validate `PREVIEW_SECRET`, set an `HttpOnly`, `Secure`, `SameSite=Lax` cookie, and redirect to the matching preview route.
- Added draft Sanity client/fetch layer using `SANITY_READ_TOKEN`, `perspective: drafts`, and `useCdn: false`.
- Added protected `/preview/work/[slug]` and `/preview/writing/[slug]` routes for draft Work and Writing content.
- Kept published Work/Writing pages prerendered/static.

Validation
- [x] `bun run build`
- [x] checked preview secret/token are absent from prerendered static HTML/assets