### PR TITLE
Refactor personal site design system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "astro": "^6.2.1",
         "jose": "^6.2.3",
         "sanity": "^5.23.0",
-        "styled-components": "^6.1.15",
         "tailwindcss": "^4.2.4",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "astro": "^6.2.1",
     "jose": "^6.2.3",
     "sanity": "^5.23.0",
-    "styled-components": "^6.1.15",
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {

--- a/public/site-interactions.js
+++ b/public/site-interactions.js
@@ -1,0 +1,189 @@
+const finePointer = window.matchMedia('(hover: hover) and (pointer: fine)').matches;
+const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+initLinkPrefetch();
+
+if (finePointer && !reducedMotion) {
+  initCustomCursor();
+  initScrapbookHero();
+}
+
+function initLinkPrefetch() {
+  const connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  const shouldAvoidPrefetch =
+    connection?.saveData || ['slow-2g', '2g'].includes(connection?.effectiveType);
+
+  if (shouldAvoidPrefetch) {
+    return;
+  }
+
+  const prefetchedUrls = new Set();
+
+  const prefetchLink = (link) => {
+    const url = getPrefetchableUrl(link);
+
+    if (!url || prefetchedUrls.has(url.href)) {
+      return;
+    }
+
+    prefetchedUrls.add(url.href);
+
+    const prefetch = document.createElement('link');
+    prefetch.rel = 'prefetch';
+    prefetch.href = url.href;
+    prefetch.as = 'document';
+    document.head.append(prefetch);
+  };
+
+  document.addEventListener(
+    'pointerover',
+    (event) => {
+      if (!(event.target instanceof Element)) return;
+
+      const link = event.target.closest('a[href]');
+      if (link) {
+        prefetchLink(link);
+      }
+    },
+    { passive: true },
+  );
+
+  document.addEventListener('focusin', (event) => {
+    if (!(event.target instanceof Element)) return;
+
+    const link = event.target.closest('a[href]');
+    if (link) {
+      prefetchLink(link);
+    }
+  });
+}
+
+function getPrefetchableUrl(link) {
+  if (
+    link.target === '_blank' ||
+    link.hasAttribute('download') ||
+    link.dataset.prefetch === 'false'
+  ) {
+    return null;
+  }
+
+  const url = new URL(link.href, window.location.href);
+
+  if (
+    url.origin !== window.location.origin ||
+    url.pathname === window.location.pathname ||
+    url.protocol !== 'http:' && url.protocol !== 'https:'
+  ) {
+    return null;
+  }
+
+  url.hash = '';
+  return url;
+}
+
+function initCustomCursor() {
+  const cursor = document.querySelector('.custom-cursor');
+  const cursorLabel = cursor?.querySelector('.custom-cursor-label');
+
+  if (!cursor || !cursorLabel) {
+    return;
+  }
+
+  document.body.classList.add('custom-cursor-ready');
+
+  let cursorX = window.innerWidth / 2;
+  let cursorY = window.innerHeight / 2;
+  let targetX = cursorX;
+  let targetY = cursorY;
+
+  const animateCursor = () => {
+    cursorX += (targetX - cursorX) * 0.24;
+    cursorY += (targetY - cursorY) * 0.24;
+    cursor.style.transform = `translate3d(${cursorX}px, ${cursorY}px, 0)`;
+    requestAnimationFrame(animateCursor);
+  };
+
+  window.addEventListener(
+    'pointermove',
+    (event) => {
+      targetX = event.clientX;
+      targetY = event.clientY;
+    },
+    { passive: true },
+  );
+
+  document.addEventListener('pointerover', (event) => {
+    if (!(event.target instanceof Element)) return;
+
+    const target = event.target.closest('a, button, [data-cursor-label]');
+    if (!target) return;
+
+    cursorLabel.textContent = target.dataset.cursorLabel || 'open';
+    cursor.classList.add('is-active');
+  });
+
+  document.addEventListener('pointerout', (event) => {
+    if (!(event.target instanceof Element)) return;
+
+    const target = event.target.closest('a, button, [data-cursor-label]');
+    if (!target || target.contains(event.relatedTarget)) return;
+
+    cursor.classList.remove('is-active');
+  });
+
+  animateCursor();
+}
+
+function initScrapbookHero() {
+  const heroStage = document.querySelector('.scrapbook-stage');
+
+  if (!heroStage) {
+    return;
+  }
+
+  const resetHero = () => {
+    [
+      '--hero-main-x',
+      '--hero-main-y',
+      '--hero-note-x',
+      '--hero-note-y',
+      '--hero-small-x',
+      '--hero-small-y',
+      '--hero-stamp-x',
+      '--hero-stamp-y',
+      '--hero-doodle-x',
+      '--hero-doodle-y',
+      '--hero-tilt-x',
+      '--hero-tilt-y',
+      '--hero-note-tilt-x',
+      '--hero-note-tilt-y',
+    ].forEach((property) => heroStage.style.removeProperty(property));
+  };
+
+  heroStage.addEventListener(
+    'pointermove',
+    (event) => {
+      const rect = heroStage.getBoundingClientRect();
+      const x = (event.clientX - rect.left) / rect.width - 0.5;
+      const y = (event.clientY - rect.top) / rect.height - 0.5;
+
+      heroStage.style.setProperty('--hero-main-x', `${x * -18}px`);
+      heroStage.style.setProperty('--hero-main-y', `${y * -14}px`);
+      heroStage.style.setProperty('--hero-note-x', `${x * 24}px`);
+      heroStage.style.setProperty('--hero-note-y', `${y * 18}px`);
+      heroStage.style.setProperty('--hero-small-x', `${x * 38}px`);
+      heroStage.style.setProperty('--hero-small-y', `${y * 30}px`);
+      heroStage.style.setProperty('--hero-stamp-x', `${x * -20}px`);
+      heroStage.style.setProperty('--hero-stamp-y', `${y * 12}px`);
+      heroStage.style.setProperty('--hero-doodle-x', `${x * -15}px`);
+      heroStage.style.setProperty('--hero-doodle-y', `${y * -10}px`);
+      heroStage.style.setProperty('--hero-tilt-x', `${y * -5}deg`);
+      heroStage.style.setProperty('--hero-tilt-y', `${x * 5}deg`);
+      heroStage.style.setProperty('--hero-note-tilt-x', `${y * 2.5}deg`);
+      heroStage.style.setProperty('--hero-note-tilt-y', `${x * -2.5}deg`);
+    },
+    { passive: true },
+  );
+
+  heroStage.addEventListener('pointerleave', resetHero);
+}

--- a/src/features/work/workIndex.ts
+++ b/src/features/work/workIndex.ts
@@ -1,0 +1,93 @@
+import type { PublishedWork, PublishedWorkStatus, SanityImage } from '../../sanity/published';
+
+type WorkListItem = Pick<
+  PublishedWork,
+  'liveUrl' | 'proofTags' | 'repoUrl' | 'role' | 'slug' | 'stack' | 'status' | 'summary' | 'title'
+> & {
+  coverImage?: SanityImage;
+};
+
+export type WorkCardItem = {
+  coverImage?: SanityImage;
+  href: string;
+  liveUrl?: string;
+  mark: string;
+  primaryActionLabel: string;
+  proofTags: string[];
+  repoUrl?: string;
+  role: string;
+  stack: string[];
+  status: PublishedWorkStatus;
+  summary: string;
+  title: string;
+  tone: string;
+};
+
+const fallbackWorks: WorkListItem[] = [
+  {
+    title: 'Invitasi',
+    slug: 'invitasi',
+    summary:
+      'Wedding invitation platform for couples and organizers to publish invitations, manage RSVPs, and grow into planning workflows.',
+    status: 'ongoing',
+    role: 'Product builder / design engineer',
+    proofTags: ['Onboarding', 'RSVP', 'Builder'],
+    stack: ['Next.js', 'TypeScript', 'Postgres'],
+    liveUrl: 'https://invitasi.app',
+  },
+  {
+    title: 'Devault',
+    slug: 'devault',
+    summary:
+      'Community SaaS for Discord teams to save useful resources from chat and monitor high-signal channels.',
+    status: 'live',
+    role: 'Product builder / UI systems',
+    proofTags: ['Community workflow', 'Dashboard'],
+    stack: ['Next.js', 'TanStack', 'Postgres'],
+    liveUrl: 'https://devault.app',
+  },
+  {
+    title: 'Standout Headshot',
+    slug: 'standout-headshot',
+    summary:
+      'AI image product for job seekers and companies to generate professional headshots with fast comprehension and conversion.',
+    status: 'live',
+    role: 'Creative technologist / product builder',
+    proofTags: ['AI images', 'Conversion'],
+    stack: ['Next.js', 'AI workflow', 'Cloudflare'],
+    liveUrl: 'https://standoutheadshot.com',
+  },
+];
+
+const workTones = ['var(--color-sunshine-yellow)', 'var(--color-frost-gray)', 'var(--color-electric-purple)'];
+
+export function createWorkCards(works: PublishedWork[]): WorkCardItem[] {
+  const hasPublishedWorks = works.length > 0;
+  const selectedWorks: WorkListItem[] = hasPublishedWorks ? works : fallbackWorks;
+
+  return selectedWorks.map((work, index) => ({
+    title: work.title,
+    summary: work.summary,
+    role: `${work.role} / ${toStatusLabel(work.status)}`,
+    proofTags: work.proofTags,
+    stack: work.stack,
+    status: work.status,
+    href: hasPublishedWorks ? `/work/${work.slug}` : work.liveUrl,
+    liveUrl: hasPublishedWorks ? work.liveUrl : undefined,
+    repoUrl: work.repoUrl,
+    coverImage: work.coverImage,
+    tone: workTones[index % workTones.length],
+    mark: work.title.charAt(0).toUpperCase() || (index + 1).toString(),
+    primaryActionLabel: hasPublishedWorks ? 'Read proof' : 'Open live',
+  }));
+}
+
+function toStatusLabel(status: PublishedWorkStatus): string {
+  return (
+    {
+      live: 'live',
+      ongoing: 'ongoing',
+      paused: 'paused',
+    }[status] ?? status
+  );
+}

--- a/src/features/writing/writingIndex.ts
+++ b/src/features/writing/writingIndex.ts
@@ -1,0 +1,64 @@
+import type { PublishedPost } from '../../sanity/published';
+
+export type WritingCardItem = {
+  eyebrow: string;
+  href: string;
+  mark: string;
+  summary: string;
+  tags: string[];
+  title: string;
+  tone: string;
+};
+
+const fallbackPosts: WritingCardItem[] = [
+  {
+    title: 'Why I am rebuilding my site around product building',
+    eyebrow: 'Product Notes',
+    summary: 'A positioning note on making selected product work easier to judge in the first ten seconds.',
+    tags: ['Planned'],
+    href: '/writing/why-i-am-rebuilding-my-site-around-product-building',
+    tone: 'var(--color-muted-taupe)',
+    mark: '01',
+  },
+  {
+    title: 'What video work taught me about product building',
+    eyebrow: 'Creative Process',
+    summary: 'How narrative, pacing, and visual judgment from media work transfer into product design.',
+    tags: ['Planned'],
+    href: '/writing/what-video-work-taught-me-about-product-building',
+    tone: 'var(--color-frost-gray)',
+    mark: '02',
+  },
+  {
+    title: 'How I use AI as a build partner',
+    eyebrow: 'Build Logs',
+    summary: 'A practical look at AI-assisted implementation without outsourcing product judgment.',
+    tags: ['Draft idea'],
+    href: '/writing',
+    tone: 'var(--color-sunshine-yellow)',
+    mark: '03',
+  },
+];
+
+export function createWritingCards(posts: PublishedPost[]): WritingCardItem[] {
+  if (posts.length === 0) {
+    return fallbackPosts;
+  }
+
+  return posts.map((post, index) => ({
+    title: post.title,
+    eyebrow: post.category.title,
+    summary: post.excerpt,
+    tags: [new Date(post.publishedAt).getFullYear().toString()],
+    href: `/writing/${post.slug}`,
+    tone: index % 2 === 0 ? 'var(--color-muted-taupe)' : 'var(--color-frost-gray)',
+    mark: (index + 1).toString().padStart(2, '0'),
+  }));
+}
+
+export function splitWritingMasonryColumns(items: WritingCardItem[]): WritingCardItem[][] {
+  return [
+    items.filter((_, index) => index % 2 === 0),
+    items.filter((_, index) => index % 2 === 1),
+  ];
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,14 +25,17 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl);
     <link rel="canonical" href={canonicalUrl.toString()} />
   </head>
   <body>
+    <div class="custom-cursor" aria-hidden="true">
+      <span class="custom-cursor-dot"></span>
+      <span class="custom-cursor-label">view</span>
+    </div>
     <header class="site-header">
       <div class="page-shell site-header-inner">
-        <a class="site-brand" href="/" aria-label="Homepage">Dhafin</a>
+        <a class="site-brand" href="/" aria-label="Homepage">DHAFIN</a>
         <nav class="site-nav" aria-label="Primary">
-          <a class="site-nav-link" href="/work">Work</a>
-          <a class="site-nav-link" href="/writing">Writing</a>
-          <a class="site-nav-link" href="/about">About</a>
-          <a class="site-nav-link" href="/style-preview">Style</a>
+          <a class="site-nav-link" href="/work">WORK</a>
+          <a class="site-nav-link" href="/writing">PLAYGROUND</a>
+          <a class="site-nav-link" href="/about">ABOUT</a>
         </nav>
       </div>
     </header>
@@ -41,9 +44,14 @@ const canonicalUrl = new URL(Astro.url.pathname, siteUrl);
     </main>
     <footer class="site-footer">
       <div class="page-shell site-footer-inner">
-        <span>Dhafin</span>
-        <span>Product-shaped ideas into usable web experiences.</span>
+        <span>DHAFIN</span>
+        <nav class="site-footer-links" aria-label="Footer">
+          <a href="/work">WORK</a>
+          <a href="/writing">PLAYGROUND</a>
+          <a href="/about">ABOUT</a>
+        </nav>
       </div>
     </footer>
+    <script is:inline type="module" src="/site-interactions.js"></script>
   </body>
 </html>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -7,7 +7,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   title="About | Dhafin"
   description="About Dhafin, a product builder focused on design engineering and AI-assisted shipping."
 >
-  <section class="editorial-hero" aria-labelledby="about-title">
+  <section class="editorial-hero page-hero" aria-labelledby="about-title">
     <div class="section">
       <p class="eyebrow">About</p>
       <h1 id="about-title" class="display">Focused product builder with creative range.</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,106 +1,108 @@
 ---
-import ArticleCard from '../components/ArticleCard.astro';
-import Button from '../components/Button.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
+
+const projects = [
+  {
+    title: 'Invitasi',
+    meta: 'SaaS workflow - 2024',
+    summary: 'End-to-end event management platform for organizers and attendees.',
+    href: '/work/invitasi',
+    visual: 'events',
+  },
+  {
+    title: 'Devault',
+    meta: 'Team tooling - 2023',
+    summary: 'Secure capture and monitoring spaces for teams that live in chat.',
+    href: '/work/devault',
+    visual: 'vault',
+  },
+  {
+    title: 'Standout Headshot',
+    meta: 'AI product - 2023',
+    summary: 'A conversion-minded image workflow for professional profiles.',
+    href: '/work/standout-headshot',
+    visual: 'headshot',
+  },
+  {
+    title: 'Product Systems Notes',
+    meta: 'Writing - ongoing',
+    summary: 'Short essays on product taste, interface detail, and build loops.',
+    href: '/writing',
+    visual: 'notes',
+  },
+  {
+    title: 'Design Engineering',
+    meta: 'Practice - current',
+    summary: 'Front-end systems, interaction patterns, and launchable UI.',
+    href: '/about',
+    visual: 'studio',
+  },
+  {
+    title: 'AI Assisted Shipping',
+    meta: 'Workflow - current',
+    summary: 'Using agents to move faster without outsourcing product judgment.',
+    href: '/writing',
+    visual: 'shipping',
+  },
+];
 ---
 
 <BaseLayout
   title="Dhafin"
   description="Focused on design engineering, 0-to-1 SaaS workflows, and AI-assisted shipping."
 >
-  <section class="editorial-hero" aria-labelledby="home-title">
-    <div class="section">
-      <p class="eyebrow">Design engineering / 0-to-1 products</p>
-      <h1 id="home-title" class="display">I build product-shaped ideas into usable web experiences.</h1>
-      <p class="body-copy">
-        Focused on SaaS workflows, product direction, interface detail, and AI-assisted shipping.
-      </p>
-      <div>
-        <Button href="/work" variant="pill">View work</Button>
-      </div>
-    </div>
-    <aside class="editorial-panel" aria-label="Profile summary">
-      <p class="heading">Taste, product sense, and fast build loops.</p>
-      <div class="stat-row">
-        <div class="stat-item">
-          <span class="stat-value tabular-nums">03</span>
-          <span class="stat-label">Selected products</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value">AI</span>
-          <span class="stat-label">Build partner</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-value">UX</span>
-          <span class="stat-label">Primary proof</span>
-        </div>
-      </div>
-      <p class="body-copy">
-        The site favors proof over self-description: product screenshots, case-study notes,
-        launch decisions, and direct contact paths.
-      </p>
-    </aside>
-  </section>
+  <section class="scrapbook-hero" aria-labelledby="home-title">
+    <div class="scrapbook-stage" data-cursor-label="tilt">
+      <article class="paper-card paper-card-main" aria-label="Intro card">
+        <p class="paper-kicker">design engineering / 0-to-1 products</p>
+        <h1 id="home-title">
+          Product ideas into interfaces people can actually use.
+        </h1>
+      </article>
 
-  <section class="section" aria-labelledby="focus-title">
-    <h2 id="focus-title" class="heading">Current position</h2>
-    <div class="rule-list">
-      <div class="rule-item">
-        <p class="eyebrow">Build</p>
-        <p class="body-copy">
-          Shape rough ideas into understandable product flows, especially onboarding,
-          dashboards, and first useful workflows.
+      <article class="paper-card paper-card-note" aria-label="Current focus">
+        <p>
+          Currently shaping SaaS workflows, writing about product craft, and shipping with AI without outsourcing taste.
         </p>
+      </article>
+
+      <div class="paper-card paper-card-name" aria-label="Dhafin mark">DHFN</div>
+
+      <div class="paper-card paper-card-stamp" aria-hidden="true">
+        <span>SHIP</span>
+        <span>CRAFT</span>
+        <span>REPEAT</span>
       </div>
-      <div class="rule-item">
-        <p class="eyebrow">Design</p>
-        <p class="body-copy">
-          Use restrained editorial structure, clear information hierarchy, and product
-          screenshots instead of decorative portfolio effects.
-        </p>
-      </div>
-      <div class="rule-item">
-        <p class="eyebrow">Ship</p>
-        <p class="body-copy">
-          Work quickly with AI-assisted implementation, then make product and UX decisions with
-          deliberate human judgment.
-        </p>
+
+      <div class="paper-card paper-card-doodle" aria-hidden="true">
+        <span class="doodle-flower">✳</span>
+        <span class="doodle-stem">│╲</span>
+        <span class="doodle-ground">⌞⌟</span>
       </div>
     </div>
   </section>
 
-  <section class="section section-taupe" aria-labelledby="work-title">
-    <div class="section">
-      <h2 id="work-title" class="heading">Selected work</h2>
-      <div class="grid-three">
-        <ArticleCard
-          title="Invitasi"
-          eyebrow="SaaS workflow"
-          summary="Wedding invitation platform for polished invitations, RSVP management, and planning workflows."
-          tags={['Product direction', 'Interface design']}
-          href="/work/invitasi"
-          tone="var(--color-sunshine-yellow)"
-          mark="I"
-        />
-        <ArticleCard
-          title="Devault"
-          eyebrow="Community SaaS"
-          summary="Discord resource capture and monitoring workspace for teams that live in chat."
-          tags={['Dashboard UX', 'Product build']}
-          href="/work/devault"
-          tone="var(--color-frost-gray)"
-          mark="D"
-        />
-        <ArticleCard
-          title="Standout Headshot"
-          eyebrow="AI product"
-          summary="Fast professional headshot generation flow shaped around conversion and clarity."
-          tags={['AI workflow', 'UX direction']}
-          href="/work/standout-headshot"
-          tone="var(--color-electric-purple)"
-          mark="S"
-        />
-      </div>
+  <section class="project-wall" aria-labelledby="work-title">
+    <h2 id="work-title" class="sr-only">Selected work</h2>
+    <div class="project-grid">
+      {
+        projects.map((project) => (
+          <a class="project-tile" href={project.href}>
+            <div class={`project-visual project-visual-${project.visual}`} aria-hidden="true">
+              <div class="visual-inner">
+                <span></span>
+                <span></span>
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+            </div>
+            <p class="project-meta">{project.meta}</p>
+            <h3>{project.title}</h3>
+            <p>{project.summary}</p>
+          </a>
+        ))
+      }
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -1,51 +1,9 @@
 ---
 import WorkCard from '../components/WorkCard.astro';
+import { createWorkCards } from '../features/work/workIndex';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { PublishedContentConfigError, getPublishedWorks } from '../sanity/published';
-import type { PublishedWork, PublishedWorkStatus, SanityImage } from '../sanity/published';
-
-type WorkListItem = Pick<
-  PublishedWork,
-  'liveUrl' | 'proofTags' | 'repoUrl' | 'role' | 'slug' | 'stack' | 'status' | 'summary' | 'title'
-> & {
-  coverImage?: SanityImage;
-};
-
-const fallbackWorks: WorkListItem[] = [
-  {
-    title: 'Invitasi',
-    slug: 'invitasi',
-    summary:
-      'Wedding invitation platform for couples and organizers to publish invitations, manage RSVPs, and grow into planning workflows.',
-    status: 'ongoing',
-    role: 'Product builder / design engineer',
-    proofTags: ['Onboarding', 'RSVP', 'Builder'],
-    stack: ['Next.js', 'TypeScript', 'Postgres'],
-    liveUrl: 'https://invitasi.app',
-  },
-  {
-    title: 'Devault',
-    slug: 'devault',
-    summary:
-      'Community SaaS for Discord teams to save useful resources from chat and monitor high-signal channels.',
-    status: 'live',
-    role: 'Product builder / UI systems',
-    proofTags: ['Community workflow', 'Dashboard'],
-    stack: ['Next.js', 'TanStack', 'Postgres'],
-    liveUrl: 'https://devault.app',
-  },
-  {
-    title: 'Standout Headshot',
-    slug: 'standout-headshot',
-    summary:
-      'AI image product for job seekers and companies to generate professional headshots with fast comprehension and conversion.',
-    status: 'live',
-    role: 'Creative technologist / product builder',
-    proofTags: ['AI images', 'Conversion'],
-    stack: ['Next.js', 'AI workflow', 'Cloudflare'],
-    liveUrl: 'https://standoutheadshot.com',
-  },
-];
+import type { PublishedWork } from '../sanity/published';
 
 let works: PublishedWork[] = [];
 
@@ -57,58 +15,22 @@ try {
   }
 }
 
-const selectedWorks: WorkListItem[] = works.length > 0 ? works : fallbackWorks;
-const hasPublishedWorks = works.length > 0;
-
-function workTone(index: number): string {
-  return ['var(--color-sunshine-yellow)', 'var(--color-frost-gray)', 'var(--color-electric-purple)'][index % 3];
-}
-
-function workMark(work: WorkListItem, index: number): string {
-  return work.title.charAt(0).toUpperCase() || (index + 1).toString();
-}
-
-function toStatusLabel(status: PublishedWorkStatus): string {
-  return (
-    {
-      live: 'live',
-      ongoing: 'ongoing',
-      paused: 'paused',
-    }[status] ?? status
-  );
-}
+const workCards = createWorkCards(works);
 ---
 
 <BaseLayout title="Work | Dhafin" description="Selected product-building work by Dhafin.">
-  <section class="section" aria-labelledby="work-title">
+  <section class="section page-hero" aria-labelledby="work-title">
     <p class="eyebrow">Selected work</p>
-    <h1 id="work-title" class="display">Product proof before chronology.</h1>
+    <h1 id="work-title" class="display">A simple index of shipped work.</h1>
     <p class="body-copy">
-      Work is ordered by positioning strength: product direction, UX clarity, shipped workflows,
-      and evidence of taste.
+      Fewer decorative layers, clearer project summaries, and enough context to decide what to open next.
     </p>
   </section>
 
-  <section class="section section-taupe" aria-label="Selected product cards">
+  <section class="section section-taupe work-wall-section" aria-label="Selected product cards">
     <div class="work-list">
       {
-        selectedWorks.map((work, index) => (
-          <WorkCard
-            title={work.title}
-            summary={work.summary}
-            role={`${work.role} / ${toStatusLabel(work.status)}`}
-            proofTags={work.proofTags}
-            stack={work.stack}
-            status={work.status}
-            href={hasPublishedWorks ? `/work/${work.slug}` : work.liveUrl}
-            liveUrl={hasPublishedWorks ? work.liveUrl : undefined}
-            repoUrl={work.repoUrl}
-            coverImage={work.coverImage}
-            tone={workTone(index)}
-            mark={workMark(work, index)}
-            primaryActionLabel={hasPublishedWorks ? 'Read proof' : 'Open live'}
-          />
-        ))
+        workCards.map((work) => <WorkCard {...work} />)
       }
     </div>
   </section>

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -1,5 +1,6 @@
 ---
 import ArticleCard from '../components/ArticleCard.astro';
+import { createWritingCards, splitWritingMasonryColumns } from '../features/writing/writingIndex';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { PublishedContentConfigError, getPublishedPosts } from '../sanity/published';
 import type { PublishedPost } from '../sanity/published';
@@ -13,13 +14,15 @@ try {
     throw error;
   }
 }
+
+const masonryColumns = splitWritingMasonryColumns(createWritingCards(posts));
 ---
 
 <BaseLayout
   title="Writing | Dhafin"
   description="Build logs, product notes, creative process, and personal lessons by Dhafin."
 >
-  <section class="section" aria-labelledby="writing-title">
+  <section class="section page-hero" aria-labelledby="writing-title">
     <p class="eyebrow">Writing</p>
     <h1 id="writing-title" class="display">Build notes with a product lens.</h1>
     <p class="body-copy">
@@ -28,51 +31,15 @@ try {
     </p>
   </section>
 
-  <section class="grid-three" aria-label="Published writing">
-    {
-      posts.length > 0 ? (
-        posts.map((post, index) => (
-          <ArticleCard
-            title={post.title}
-            eyebrow={post.category.title}
-            summary={post.excerpt}
-            tags={[new Date(post.publishedAt).getFullYear().toString()]}
-            href={`/writing/${post.slug}`}
-            tone={index % 2 === 0 ? 'var(--color-muted-taupe)' : 'var(--color-frost-gray)'}
-            mark={(index + 1).toString().padStart(2, '0')}
-          />
-        ))
-      ) : (
-        <>
-          <ArticleCard
-            title="Why I am rebuilding my site around product building"
-            eyebrow="Product Notes"
-            summary="A positioning note on making selected product work easier to judge in the first ten seconds."
-            tags={['Planned']}
-            href="/writing/why-i-am-rebuilding-my-site-around-product-building"
-            tone="var(--color-muted-taupe)"
-            mark="01"
-          />
-          <ArticleCard
-            title="What video work taught me about product building"
-            eyebrow="Creative Process"
-            summary="How narrative, pacing, and visual judgment from media work transfer into product design."
-            tags={['Planned']}
-            href="/writing/what-video-work-taught-me-about-product-building"
-            tone="var(--color-frost-gray)"
-            mark="02"
-          />
-          <ArticleCard
-            title="How I use AI as a build partner"
-            eyebrow="Build Logs"
-            summary="A practical look at AI-assisted implementation without outsourcing product judgment."
-            tags={['Draft idea']}
-            href="/writing"
-            tone="var(--color-sunshine-yellow)"
-            mark="03"
-          />
-        </>
-      )
-    }
+  <section class="post-masonry" aria-label="Published writing">
+    {masonryColumns.map((column) => (
+      <div class="post-masonry-column">
+        {column.map((post) => (
+          <div class="post-masonry-item">
+            <ArticleCard {...post} />
+          </div>
+        ))}
+      </div>
+    ))}
   </section>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,14 +3,14 @@
 :root {
   color-scheme: light;
 
-  --color-black-ink: #2b2b2b;
+  --color-black-ink: #101624;
   --color-pure-white: #ffffff;
-  --color-frost-gray: #f0efef;
-  --color-medium-gray: #676767;
-  --color-muted-taupe: #faead9;
-  --color-electric-purple: #8147ff;
-  --color-sunshine-yellow: #ffd519;
-  --color-deep-indigo: #6219ff;
+  --color-frost-gray: #f3f5f5;
+  --color-medium-gray: #596575;
+  --color-muted-taupe: #eef3ef;
+  --color-electric-purple: #2f6253;
+  --color-sunshine-yellow: #e8ca62;
+  --color-deep-indigo: #123b56;
   --gradient-risograph: linear-gradient(rgb(255 255 255) 20%, rgb(0 0 0 / 8%) 20%);
 
   --font-bradford: Georgia, "Times New Roman", serif;
@@ -19,37 +19,37 @@
 
   --text-caption: 0.75rem;
   --leading-caption: 1.4;
-  --tracking-caption: 0.04em;
+  --tracking-caption: 0;
   --text-body: 1rem;
   --leading-body: 1.55;
-  --tracking-body: 0.005em;
+  --tracking-body: 0;
   --text-meta: 0.8125rem;
   --leading-meta: 1.45;
-  --tracking-meta: 0.08em;
-  --text-heading: clamp(1.5625rem, 2.2vw, 2rem);
+  --tracking-meta: 0;
+  --text-heading: 2rem;
   --leading-heading: 1.22;
-  --tracking-heading: 0.035em;
-  --text-display: clamp(2.35rem, 7vw, 5.75rem);
+  --tracking-heading: 0;
+  --text-display: 5.25rem;
   --leading-display: 0.98;
-  --tracking-display: 0.018em;
+  --tracking-display: 0;
 
   --page-max-width: 1200px;
   --section-gap: clamp(2.5rem, 7vw, 5rem);
-  --radius-default: 0;
+  --radius-default: 8px;
   --radius-buttons: 75px;
   --border-ink: 1px solid var(--color-black-ink);
-  --border-subtle: 1px solid rgb(43 43 43 / 14%);
+  --border-subtle: 1px solid rgb(16 22 36 / 14%);
 }
 
 @theme {
-  --color-black-ink: #2b2b2b;
+  --color-black-ink: #101624;
   --color-pure-white: #ffffff;
-  --color-frost-gray: #f0efef;
-  --color-medium-gray: #676767;
-  --color-muted-taupe: #faead9;
-  --color-electric-purple: #8147ff;
-  --color-sunshine-yellow: #ffd519;
-  --color-deep-indigo: #6219ff;
+  --color-frost-gray: #f3f5f5;
+  --color-medium-gray: #596575;
+  --color-muted-taupe: #eef3ef;
+  --color-electric-purple: #2f6253;
+  --color-sunshine-yellow: #e8ca62;
+  --color-deep-indigo: #123b56;
 
   --font-bradford: Georgia, "Times New Roman", serif;
   --font-labilvariable: "Open Sans", ui-sans-serif, system-ui, sans-serif;
@@ -58,8 +58,8 @@
   --text-caption: 0.75rem;
   --text-body: 1rem;
   --text-meta: 0.8125rem;
-  --text-heading: clamp(1.5625rem, 2.2vw, 2rem);
-  --text-display: clamp(2.35rem, 7vw, 5.75rem);
+  --text-heading: 2rem;
+  --text-display: 5.25rem;
 
   --spacing-4: 0.25rem;
   --spacing-5: 0.3125rem;
@@ -97,9 +97,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background:
-    linear-gradient(90deg, rgb(43 43 43 / 4%) 1px, transparent 1px) 0 0 / 25% 100%,
-    var(--color-pure-white);
+  background: #f7f6f3;
 }
 
 body,
@@ -137,6 +135,70 @@ button {
   cursor: pointer;
 }
 
+.custom-cursor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 999;
+  display: none;
+  align-items: center;
+  gap: 0.45rem;
+  pointer-events: none;
+  transform: translate3d(-3rem, -3rem, 0);
+  transition: opacity 140ms ease;
+}
+
+.custom-cursor-dot {
+  width: 0.72rem;
+  height: 0.72rem;
+  border: 1px solid rgb(16 22 36 / 42%);
+  border-radius: 999px;
+  background: #ff4617;
+  box-shadow: 0 0 0 0.35rem rgb(255 250 240 / 72%);
+  transform: translate(-50%, -50%);
+  transition: width 160ms ease, height 160ms ease, background-color 160ms ease;
+}
+
+.custom-cursor-label {
+  position: absolute;
+  left: 0.85rem;
+  top: -0.95rem;
+  border: 1px solid rgb(16 22 36 / 18%);
+  padding: 0.18rem 0.38rem;
+  background: #fffaf0;
+  color: rgb(16 22 36 / 64%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  line-height: 1;
+  opacity: 0;
+  text-transform: uppercase;
+  transform: translateY(0.2rem) rotate(-3deg);
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+
+.custom-cursor-ready,
+.custom-cursor-ready a,
+.custom-cursor-ready button,
+.custom-cursor-ready [data-cursor-label] {
+  cursor: none;
+}
+
+.custom-cursor-ready .custom-cursor {
+  display: flex;
+}
+
+.custom-cursor.is-active .custom-cursor-dot {
+  width: 1.35rem;
+  height: 1.35rem;
+  background: #cddd58;
+}
+
+.custom-cursor.is-active .custom-cursor-label {
+  opacity: 1;
+  transform: translateY(0) rotate(-3deg);
+}
+
 ::selection {
   background: var(--color-sunshine-yellow);
   color: var(--color-black-ink);
@@ -156,9 +218,9 @@ button {
   position: sticky;
   top: 0;
   z-index: 10;
-  border-bottom: var(--border-ink);
-  background: color-mix(in srgb, var(--color-pure-white) 92%, transparent);
-  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgb(16 22 36 / 10%);
+  background: rgb(247 246 243 / 94%);
+  backdrop-filter: blur(10px);
 }
 
 @utility site-header-inner {
@@ -166,43 +228,78 @@ button {
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-20);
-  min-height: 4rem;
+  min-height: 3.25rem;
+  padding-block: 0;
 }
 
 @utility site-brand {
   color: var(--color-black-ink);
-  font-family: var(--font-labilvariable);
-  font-size: var(--text-meta);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: var(--text-caption);
+  font-weight: 700;
   line-height: var(--leading-meta);
   letter-spacing: var(--tracking-meta);
   text-decoration: none;
+  white-space: nowrap;
+  opacity: 0.42;
 }
 
 @utility site-nav {
   display: flex;
   align-items: center;
-  gap: var(--spacing-10);
+  gap: var(--spacing-30);
 }
 
 @utility site-nav-link {
-  color: var(--color-black-ink);
-  font-family: var(--font-labil);
+  color: rgb(16 22 36 / 42%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: var(--text-caption);
+  font-weight: 700;
   line-height: var(--leading-caption);
   letter-spacing: var(--tracking-caption);
   text-decoration: none;
 }
 
+@utility site-nav-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.375rem;
+  border-radius: var(--radius-buttons);
+  padding-inline: var(--spacing-20);
+  background: var(--color-black-ink);
+  color: var(--color-pure-white);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+a.site-nav-cta {
+  color: var(--color-pure-white);
+}
+
 @utility site-main {
   display: grid;
-  gap: var(--section-gap);
+  gap: 0;
   padding-block: var(--spacing-60) var(--spacing-80);
 }
 
+.site-main:has(.landing-hero) {
+  width: 100%;
+  padding-block: 0;
+}
+
+.site-main:has(.scrapbook-hero) {
+  width: 100%;
+  padding-block: 0;
+}
+
 @utility site-footer {
-  border-top: var(--border-ink);
-  padding-block: var(--spacing-20);
-  background: var(--color-pure-white);
+  border-top: 1px solid rgb(16 22 36 / 10%);
+  padding-block: var(--spacing-30);
+  background: #171816;
 }
 
 @utility site-footer-inner {
@@ -210,30 +307,53 @@ button {
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-20);
-  color: var(--color-medium-gray);
-  font-family: var(--font-labil);
+  color: rgb(247 246 243 / 52%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: var(--text-caption);
+  font-weight: 700;
   line-height: var(--leading-caption);
   letter-spacing: var(--tracking-caption);
 }
 
+@utility site-footer-links {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-20);
+}
+
+.site-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
 @utility eyebrow {
   margin: 0;
-  color: var(--color-black-ink);
-  font-family: var(--font-labil);
+  color: rgb(16 22 36 / 42%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: var(--text-caption);
-  font-weight: 400;
+  font-weight: 700;
   line-height: var(--leading-caption);
   letter-spacing: var(--tracking-caption);
+  text-transform: uppercase;
 }
 
 @utility display {
   margin: 0;
   max-width: 11ch;
-  font-family: var(--font-labilvariable);
-  font-size: var(--text-display);
+  color: rgb(16 22 36 / 56%);
+  font-family: var(--font-bradford);
+  font-size: clamp(3rem, 7vw, 6.2rem);
   font-weight: 400;
-  line-height: var(--leading-display);
+  line-height: 0.98;
   letter-spacing: var(--tracking-display);
   text-wrap: balance;
 }
@@ -241,7 +361,8 @@ button {
 @utility heading {
   margin: 0;
   max-width: 20ch;
-  font-family: var(--font-labilvariable);
+  color: rgb(16 22 36 / 56%);
+  font-family: var(--font-bradford);
   font-size: var(--text-heading);
   font-weight: 400;
   line-height: var(--leading-heading);
@@ -252,8 +373,8 @@ button {
 @utility body-copy {
   margin: 0;
   max-width: 62ch;
-  color: var(--color-medium-gray);
-  font-family: var(--font-bradford);
+  color: rgb(16 22 36 / 42%);
+  font-family: var(--font-labil);
   font-size: var(--text-body);
   line-height: var(--leading-body);
   letter-spacing: var(--tracking-body);
@@ -265,14 +386,14 @@ button {
   align-items: center;
   justify-content: center;
   min-height: 2.75rem;
-  border: var(--border-ink);
-  border-radius: var(--radius-default);
-  padding: 0.75rem 0.875rem;
-  background: transparent;
+  border: 1px solid rgb(16 22 36 / 32%);
+  border-radius: var(--radius-buttons);
+  padding: 0.75rem 1.25rem;
+  background: #fffaf0;
   color: var(--color-black-ink);
-  font-family: var(--font-bradford);
-  font-size: var(--text-body);
-  font-weight: 400;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: var(--text-caption);
+  font-weight: 700;
   line-height: 1;
   letter-spacing: var(--tracking-body);
   text-decoration: none;
@@ -291,60 +412,50 @@ button {
 
 @utility button-pill {
   min-height: 2.5rem;
-  border-color: var(--color-pure-white);
+  border-color: var(--color-black-ink);
   border-radius: var(--radius-buttons);
   padding: 0 var(--spacing-20);
-  background: var(--color-electric-purple);
+  background: #101624;
   color: var(--color-pure-white);
-  font-family: var(--font-labilvariable);
+  font-family: var(--font-labil);
+}
+
+a.button-pill {
+  color: var(--color-pure-white);
 }
 
 @utility button-highlight {
   border-color: var(--color-black-ink);
-  background: var(--color-sunshine-yellow);
+  background: #ff4617;
   color: var(--color-black-ink);
-  font-family: var(--font-labilvariable);
-}
-
-.button:hover {
-  @apply button-hover;
-}
-
-.button-pill:hover {
-  border-color: var(--color-black-ink);
-  background: var(--color-black-ink);
-}
-
-.button-highlight:hover {
-  background: var(--color-electric-purple);
-  color: var(--color-pure-white);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
 @utility tag {
   display: inline-flex;
   align-items: center;
   min-height: 1.625rem;
-  border-radius: var(--radius-default);
+  border-radius: 0;
   padding: var(--spacing-5) var(--spacing-10);
-  background: var(--color-frost-gray);
-  color: var(--color-black-ink);
-  font-family: var(--font-bradford);
+  background: #fffaf0;
+  color: rgb(16 22 36 / 48%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: var(--text-caption);
-  font-weight: 400;
+  font-weight: 700;
   line-height: var(--leading-caption);
   letter-spacing: var(--tracking-caption);
 }
 
 @utility tag-outline {
-  border: var(--border-ink);
+  border: 1px solid rgb(16 22 36 / 14%);
   background: transparent;
 }
 
 @utility card {
   display: grid;
-  gap: var(--spacing-10);
+  gap: var(--spacing-12);
   min-width: 0;
-  border-radius: var(--radius-default);
+  border-radius: 0;
   background: transparent;
 }
 
@@ -352,9 +463,9 @@ button {
   position: relative;
   aspect-ratio: 4 / 3;
   overflow: hidden;
-  border: var(--border-ink);
+  border: 0;
   background:
-    linear-gradient(135deg, transparent 0 48%, rgb(43 43 43 / 100%) 48% 52%, transparent 52%),
+    linear-gradient(135deg, rgb(255 255 255 / 12%), rgb(16 22 36 / 8%)),
     var(--media-tone, var(--color-muted-taupe));
 }
 
@@ -362,9 +473,9 @@ button {
   position: absolute;
   right: var(--spacing-12);
   bottom: var(--spacing-10);
-  color: var(--color-black-ink);
+  color: rgb(255 255 255 / 82%);
   font-family: var(--font-labilvariable);
-  font-size: clamp(2rem, 6vw, 4rem);
+  font-size: clamp(3rem, 9vw, 6rem);
   line-height: 1;
   letter-spacing: var(--tracking-heading);
 }
@@ -382,24 +493,40 @@ button {
 
 @utility work-list {
   display: grid;
-  gap: var(--spacing-40);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--spacing-20);
 }
 
 @utility work-card {
   display: grid;
-  grid-template-columns: minmax(16rem, 5fr) minmax(0, 7fr);
-  gap: var(--spacing-20);
-  border: var(--border-ink);
-  background: var(--color-pure-white);
+  gap: var(--spacing-12);
+  align-content: start;
+  min-width: 0;
+  border: 0;
+  padding-block: 0;
+  background: transparent;
+}
+
+.work-card:nth-child(even) {
+  transform: none;
 }
 
 @utility work-card-media {
   position: relative;
-  min-height: 20rem;
+  display: grid;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  place-items: center;
   overflow: hidden;
+  border-radius: 0;
   background:
-    linear-gradient(135deg, transparent 0 48%, rgb(43 43 43 / 100%) 48% 52%, transparent 52%),
+    linear-gradient(135deg, rgb(255 255 255 / 12%), rgb(16 22 36 / 8%)),
     var(--media-tone, var(--color-muted-taupe));
+  box-shadow: none;
+  text-decoration: none;
+  transition:
+    box-shadow 150ms ease,
+    transform 180ms cubic-bezier(0.215, 0.61, 0.355, 1);
 }
 
 .work-card-media img,
@@ -412,33 +539,73 @@ button {
 
 @utility work-card-mark {
   position: absolute;
-  right: var(--spacing-20);
-  bottom: var(--spacing-16);
-  color: var(--color-black-ink);
+  right: var(--spacing-12);
+  bottom: var(--spacing-10);
+  color: rgb(255 250 240 / 88%);
   font-family: var(--font-labilvariable);
-  font-size: clamp(4rem, 18vw, 10rem);
-  line-height: 0.85;
-  letter-spacing: var(--tracking-display);
+  font-size: clamp(3rem, 9vw, 6rem);
+  line-height: 1;
+  letter-spacing: var(--tracking-heading);
 }
 
 @utility work-card-content {
   display: grid;
   align-content: start;
   gap: var(--spacing-12);
-  padding: var(--spacing-20);
+  padding: 0;
+}
+
+.work-card .card-meta {
+  gap: var(--spacing-5);
+  margin-top: 0;
+}
+
+.work-card .tag {
+  min-height: 1.625rem;
+  border-color: rgb(16 22 36 / 14%);
+  padding: var(--spacing-5) var(--spacing-10);
+  background: #fffaf0;
+  color: rgb(16 22 36 / 48%);
+  font-size: var(--text-caption);
+}
+
+.work-card .tag + .tag::before {
+  content: none;
+}
+
+.work-card .eyebrow {
+  margin-top: calc(var(--spacing-8) * -1);
+  color: rgb(16 22 36 / 46%);
+  font-size: var(--text-caption);
+}
+
+.work-card .heading {
+  max-width: 20ch;
+  color: rgb(16 22 36 / 56%);
+  font-size: var(--text-heading);
+  line-height: var(--leading-heading);
+}
+
+.work-card .body-copy {
+  max-width: 62ch;
+  color: rgb(16 22 36 / 42%);
+  font-family: var(--font-labil);
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
 }
 
 @utility work-card-stack {
-  margin: var(--spacing-8) 0 0;
-  color: var(--color-medium-gray);
-  font-family: var(--font-labil);
+  margin: 0;
+  color: rgb(16 22 36 / 46%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: var(--text-caption);
+  font-weight: 700;
   line-height: var(--leading-caption);
   letter-spacing: var(--tracking-caption);
 }
 
 .work-card-stack span {
-  margin-right: var(--spacing-8);
+  margin-right: var(--spacing-10);
   color: var(--color-black-ink);
   text-transform: uppercase;
 }
@@ -446,8 +613,23 @@ button {
 @utility work-card-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--spacing-8);
-  margin-top: var(--spacing-8);
+  gap: var(--spacing-10);
+  margin-top: 0;
+}
+
+.work-card .button {
+  min-height: auto;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+  color: rgb(16 22 36 / 72%);
+  font-size: clamp(0.78rem, 1vw, 0.92rem);
+}
+
+.work-card .button::after {
+  margin-left: var(--spacing-8);
+  content: "->";
 }
 
 @utility work-link-row {
@@ -461,7 +643,7 @@ button {
   gap: var(--spacing-8);
   align-self: stretch;
   margin: 0;
-  border: var(--border-ink);
+  border: 0;
   background: var(--color-frost-gray);
 }
 
@@ -477,8 +659,8 @@ button {
 @utility work-proof-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  border-top: var(--border-ink);
-  border-bottom: var(--border-ink);
+  border-top: 1px solid rgb(16 22 36 / 12%);
+  border-bottom: 1px solid rgb(16 22 36 / 12%);
 }
 
 @utility work-proof-panel {
@@ -489,7 +671,7 @@ button {
 }
 
 .work-proof-panel + .work-proof-panel {
-  border-left: var(--border-ink);
+  border-left: 1px solid rgb(16 22 36 / 12%);
 }
 
 @utility work-gallery {
@@ -505,7 +687,7 @@ button {
 }
 
 .work-gallery img {
-  border: var(--border-ink);
+  border: 0;
 }
 
 @utility section {
@@ -516,23 +698,938 @@ button {
 @utility section-taupe {
   margin-inline: calc(50% - 50vw);
   padding: var(--spacing-60) max(1rem, calc((100vw - var(--page-max-width)) / 2));
-  background: var(--color-muted-taupe);
+  background: #f7f6f3;
+  content-visibility: auto;
+  contain-intrinsic-size: 48rem;
+}
+
+.scrapbook-hero {
+  display: grid;
+  min-height: clamp(39rem, 68vw, 50rem);
+  margin-inline: calc(50% - 50vw);
+  place-items: center;
+  padding: clamp(3.5rem, 8vw, 7rem) 1.5rem;
+  background: #f7f6f3;
+}
+
+.scrapbook-stage {
+  position: relative;
+  width: min(74rem, 94vw);
+  min-height: clamp(31rem, 48vw, 41rem);
+  perspective: 70rem;
+  transform-style: preserve-3d;
+}
+
+.paper-card {
+  position: absolute;
+  box-shadow: 0 1px 0 rgb(16 22 36 / 5%);
+  transform-style: preserve-3d;
+  transition: transform 360ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 180ms ease;
+  will-change: transform;
+}
+
+.paper-card-main {
+  left: 9%;
+  top: 8%;
+  width: min(39rem, 52vw);
+  min-height: 23rem;
+  padding: 3rem 3.2rem;
+  background: #fffaf0;
+  color: #111827;
+  box-shadow: 0 0 0 1px rgb(16 22 36 / 10%);
+  transform:
+    translate3d(var(--hero-main-x, 0px), var(--hero-main-y, 0px), 0)
+    rotate(-3deg)
+    rotateX(var(--hero-tilt-x, 0deg))
+    rotateY(var(--hero-tilt-y, 0deg));
+}
+
+.paper-card-main::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4.2rem;
+  background: #ff4617;
+  content: "";
+}
+
+.paper-card-main::after {
+  position: absolute;
+  inset: 2.6rem 2.7rem 2.4rem 6.2rem;
+  background:
+    linear-gradient(rgb(16 22 36 / 12%) 1px, transparent 1px) 0 4.1rem / 100% 4.1rem,
+    linear-gradient(90deg, rgb(255 70 23 / 28%) 0 0.28rem, transparent 0.28rem) 0 0 / 100% 100%;
+  content: "";
+}
+
+.paper-kicker {
+  position: relative;
+  z-index: 1;
+  margin: 0 0 var(--spacing-20);
+  color: #ff4617;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: clamp(0.9rem, 1.2vw, 1.15rem);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.paper-card-main h1 {
+  position: relative;
+  z-index: 1;
+  margin: 0.2rem 0 0;
+  max-width: 14ch;
+  font-family: var(--font-bradford);
+  font-size: clamp(2.4rem, 4.4vw, 4.65rem);
+  font-weight: 400;
+  line-height: 1.08;
+}
+
+.paper-card-note {
+  right: 9%;
+  top: 44%;
+  z-index: 2;
+  width: min(35rem, 42vw);
+  min-height: 12rem;
+  padding: 2.3rem 2.5rem 3.2rem;
+  background: #acd8fb;
+  color: #123b56;
+  transform:
+    translate3d(var(--hero-note-x, 0px), var(--hero-note-y, 0px), 2rem)
+    rotate(4deg)
+    rotateX(var(--hero-note-tilt-x, 0deg))
+    rotateY(var(--hero-note-tilt-y, 0deg));
+}
+
+.paper-card-note::before {
+  position: absolute;
+  right: 4.1rem;
+  bottom: 1.15rem;
+  z-index: 1;
+  border: 2px solid rgb(255 70 23 / 86%);
+  padding: 0.35rem 0.55rem;
+  color: rgb(255 70 23 / 86%);
+  content: "BUILDING";
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  transform: rotate(-5deg);
+}
+
+.paper-card-note::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 2.9rem;
+  height: 2.9rem;
+  background: linear-gradient(135deg, transparent 0 50%, #5cb3f0 51%);
+  content: "";
+}
+
+.paper-card-note p {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  max-width: 28ch;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: clamp(1.05rem, 1.45vw, 1.35rem);
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.paper-card-name {
+  right: 22%;
+  top: 13%;
+  width: 10rem;
+  min-height: 4.8rem;
+  display: grid;
+  place-items: center;
+  background: #cddd58;
+  color: #4f5359;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 2.3rem;
+  font-weight: 700;
+  transform:
+    translate3d(var(--hero-small-x, 0px), var(--hero-small-y, 0px), 3rem)
+    rotate(-7deg);
+}
+
+.paper-card-stamp {
+  right: 3%;
+  top: 22%;
+  display: inline-grid;
+  gap: var(--spacing-8);
+  width: max-content;
+  padding: 0.75rem 1rem;
+  border: 2px solid #ff4617;
+  color: #ff4617;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.05;
+  transform:
+    translate3d(var(--hero-stamp-x, 0px), var(--hero-stamp-y, 0px), 1rem)
+    rotate(12deg);
+}
+
+.paper-card-doodle {
+  left: 0;
+  top: 48%;
+  width: 9rem;
+  height: 9rem;
+  display: grid;
+  place-items: center;
+  background: #ffc8b0;
+  color: #111;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1;
+  transform:
+    translate3d(var(--hero-doodle-x, 0px), var(--hero-doodle-y, 0px), 1.5rem)
+    rotate(-12deg);
+}
+
+.doodle-flower {
+  color: #ff5f91;
+  transform: translateY(0.6rem);
+}
+
+.doodle-stem {
+  transform: translateY(-0.1rem);
+}
+
+.doodle-ground {
+  transform: translateY(-0.7rem);
+}
+
+.project-wall {
+  margin-inline: calc(50% - 50vw);
+  padding: 0 clamp(1rem, 3vw, 2rem) clamp(4rem, 8vw, 8rem);
+  background: #f7f6f3;
+  content-visibility: auto;
+  contain-intrinsic-size: 58rem;
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2rem, 4vw, 3.5rem) clamp(1.5rem, 3vw, 2rem);
+}
+
+.project-tile {
+  display: block;
+  min-width: 0;
+  color: rgb(16 22 36 / 46%);
+  text-decoration: none;
+}
+
+.project-visual {
+  display: grid;
+  min-height: clamp(20rem, 34vw, 31rem);
+  margin-bottom: var(--spacing-16);
+  place-items: center;
+  overflow: hidden;
+  background: #fff;
+}
+
+.project-tile:nth-child(even) {
+  transform: translateY(0.75rem);
+}
+
+.project-meta {
+  margin: 0 0 var(--spacing-8);
+  color: rgb(16 22 36 / 38%);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: clamp(0.85rem, 1.35vw, 1.25rem);
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.project-tile h3 {
+  margin: 0;
+  color: rgb(16 22 36 / 52%);
+  font-family: var(--font-bradford);
+  font-size: clamp(1.9rem, 3vw, 3rem);
+  font-weight: 400;
+  line-height: 1.05;
+}
+
+.project-tile p:not(.project-meta) {
+  margin: var(--spacing-8) 0 0;
+  max-width: 36rem;
+  color: rgb(16 22 36 / 38%);
+  font-family: var(--font-labil);
+  font-size: clamp(1rem, 1.6vw, 1.55rem);
+  line-height: 1.22;
+}
+
+.visual-inner {
+  position: relative;
+  width: min(70%, 30rem);
+  aspect-ratio: 1.45;
+}
+
+.project-visual-events .visual-inner {
+  width: min(72%, 27rem);
+  border-radius: 1.1rem;
+  background: #f8faf7;
+  box-shadow: 0 0 0 1px rgb(16 22 36 / 8%);
+}
+
+.project-visual-events span {
+  position: absolute;
+  bottom: 18%;
+  width: 9%;
+  border-radius: 999px 999px 0 0;
+  background: #cbd5dc;
+}
+
+.project-visual-events span:nth-child(1) {
+  left: 15%;
+  height: 28%;
+}
+
+.project-visual-events span:nth-child(2) {
+  left: 31%;
+  height: 47%;
+  background: #f0dda3;
+}
+
+.project-visual-events span:nth-child(3) {
+  left: 47%;
+  height: 34%;
+}
+
+.project-visual-events span:nth-child(4) {
+  left: 62%;
+  height: 58%;
+  background: #f0dda3;
+}
+
+.project-visual-events span:nth-child(5) {
+  left: 78%;
+  height: 39%;
+}
+
+.project-visual-vault {
+  background: #095d88;
+}
+
+.project-visual-vault .visual-inner {
+  width: 78%;
+  min-height: 58%;
+  border-radius: 0.8rem;
+  background: #f8f7f1;
+  box-shadow: -3rem 2rem 0 rgb(255 255 255 / 18%);
+}
+
+.project-visual-vault span {
+  display: block;
+  height: 0.85rem;
+  margin: 1.5rem 2rem;
+  border-radius: 999px;
+  background: rgb(16 22 36 / 12%);
+}
+
+.project-visual-vault span:nth-child(odd) {
+  width: 54%;
+}
+
+.project-visual-headshot {
+  background: #cfcafe;
+}
+
+.project-visual-headshot .visual-inner {
+  width: min(34%, 16rem);
+  aspect-ratio: 0.55;
+  border: 0.55rem solid #101624;
+  border-radius: 2.2rem;
+  background: #d9d7d5;
+}
+
+.project-visual-headshot span {
+  position: absolute;
+  left: 22%;
+  right: 22%;
+  height: 1.35rem;
+  border-radius: 0.35rem;
+  background: #f7f6f3;
+}
+
+.project-visual-headshot span:nth-child(1) {
+  top: 24%;
+}
+
+.project-visual-headshot span:nth-child(2) {
+  top: 39%;
+  background: #d8f0cd;
+}
+
+.project-visual-headshot span:nth-child(3) {
+  top: 54%;
+  background: #f7f6f3;
+}
+
+.project-visual-notes {
+  background: #7d80e8;
+}
+
+.project-visual-notes .visual-inner {
+  width: min(70%, 28rem);
+  aspect-ratio: 1.55;
+  background:
+    linear-gradient(90deg, transparent 0 48%, rgb(16 22 36 / 13%) 48% 50%, transparent 50%),
+    #f7f6f3;
+  box-shadow: 0 0 0 1px rgb(16 22 36 / 10%);
+}
+
+.project-visual-notes span {
+  position: absolute;
+  background: #ff4fac;
+}
+
+.project-visual-notes span:nth-child(1) {
+  left: 9%;
+  top: 13%;
+  width: 32%;
+  height: 27%;
+  background: #98e257;
+}
+
+.project-visual-notes span:nth-child(2) {
+  left: 52%;
+  top: 14%;
+  width: 35%;
+  height: 0.8rem;
+}
+
+.project-visual-notes span:nth-child(3) {
+  left: 52%;
+  top: 26%;
+  width: 31%;
+  height: 0.8rem;
+  background: #2f45c6;
+}
+
+.project-visual-studio {
+  background: #ff4fa3;
+}
+
+.project-visual-studio .visual-inner {
+  display: grid;
+  place-items: center;
+}
+
+.project-visual-studio .visual-inner::before {
+  color: #fff;
+  content: "DHAFIN";
+  font-family: var(--font-bradford);
+  font-size: clamp(2.6rem, 5vw, 5rem);
+}
+
+.project-visual-shipping {
+  background: #acd8fb;
+}
+
+.project-visual-shipping .visual-inner {
+  width: min(56%, 24rem);
+  aspect-ratio: 1.18;
+  background:
+    linear-gradient(#e52a2a 0 12%, transparent 12% 25%, #e52a2a 25% 37%, transparent 37% 50%, #e52a2a 50% 62%, transparent 62%),
+    #214d91;
+  box-shadow: 0 0.8rem 2rem rgb(16 22 36 / 18%);
+}
+
+.home-shell {
+  width: min(100% - 3rem, var(--page-max-width));
+  margin-inline: auto;
+}
+
+.landing-hero {
+  margin-inline: calc(50% - 50vw);
+  overflow: clip;
+  border-bottom: var(--border-subtle);
+  padding-block: 8.75rem var(--spacing-60);
+  background:
+    linear-gradient(90deg, rgb(16 22 36 / 4%) 1px, transparent 1px) 0 0 / 12.5% 100%,
+    linear-gradient(180deg, rgb(243 245 245) 0%, rgb(255 255 255) 78%);
+}
+
+.landing-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(19rem, 0.75fr);
+  gap: var(--spacing-60);
+  align-items: end;
+}
+
+.landing-copy {
+  display: grid;
+  gap: var(--spacing-20);
+  max-width: 52rem;
+  animation: landing-enter 360ms cubic-bezier(0.215, 0.61, 0.355, 1) both;
+}
+
+.landing-copy .display {
+  max-width: 12ch;
+  font-size: clamp(3.6rem, 6.4vw, 6.4rem);
+}
+
+.landing-copy .body-copy {
+  max-width: 42rem;
+  color: rgb(16 22 36 / 80%);
+  font-family: var(--font-labil);
+  font-size: 1.0625rem;
+}
+
+.home-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-12);
+  align-items: center;
+}
+
+.landing-brief {
+  display: grid;
+  gap: var(--spacing-20);
+  border-top: 2px solid var(--color-black-ink);
+  border-bottom: var(--border-subtle);
+  padding-block: var(--spacing-16) var(--spacing-20);
+  animation: landing-enter 360ms cubic-bezier(0.215, 0.61, 0.355, 1) 80ms both;
+}
+
+.landing-brief-label,
+.work-preview-meta {
+  margin: 0;
+  color: var(--color-medium-gray);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+  letter-spacing: var(--tracking-caption);
+}
+
+.landing-brief-list {
+  display: grid;
+  gap: var(--spacing-16);
+}
+
+.landing-brief-list p {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr);
+  gap: var(--spacing-16);
+  margin: 0;
+  border-top: var(--border-subtle);
+  padding-top: var(--spacing-16);
+  color: var(--color-black-ink);
+  font-family: var(--font-bradford);
+  font-size: 1.08rem;
+  line-height: 1.36;
+}
+
+.landing-brief-list span {
+  color: var(--color-medium-gray);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+  line-height: var(--leading-caption);
+}
+
+.explore-section {
+  margin-inline: calc(50% - 50vw);
+  border-bottom: var(--border-subtle);
+  padding-block: var(--spacing-40);
+  background: var(--color-black-ink);
+  color: var(--color-pure-white);
+}
+
+.explore-grid {
+  display: grid;
+  grid-template-columns: minmax(14rem, 0.55fr) minmax(0, 1.45fr);
+  gap: var(--spacing-40);
+}
+
+.explore-section .eyebrow,
+.explore-section .heading {
+  color: var(--color-pure-white);
+}
+
+.style-route-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--spacing-12);
+}
+
+.style-route {
+  display: grid;
+  gap: var(--spacing-16);
+  min-height: 19rem;
+  border-radius: 8px;
+  padding: var(--spacing-16);
+  background: rgb(255 255 255 / 7%);
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 14%);
+  animation: landing-enter 360ms cubic-bezier(0.215, 0.61, 0.355, 1) both;
+  transition:
+    background-color 150ms ease,
+    transform 180ms cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+
+.style-route:nth-child(2) {
+  animation-delay: 70ms;
+}
+
+.style-route:nth-child(3) {
+  animation-delay: 140ms;
+}
+
+.style-route-visual {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  grid-template-rows: 1fr 1fr;
+  gap: var(--spacing-8);
+  min-height: 8.75rem;
+}
+
+.style-route-visual span {
+  border-radius: 8px;
+  background: rgb(255 255 255 / 16%);
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 12%);
+}
+
+.style-route-visual span:first-child {
+  grid-row: 1 / -1;
+}
+
+.style-route-editorial .style-route-visual span:first-child {
+  background: var(--color-pure-white);
+}
+
+.style-route-product .style-route-visual span:nth-child(2) {
+  background: var(--color-sunshine-yellow);
+}
+
+.style-route-studio .style-route-visual span:first-child {
+  background: var(--color-electric-purple);
+}
+
+.style-route-title {
+  margin: auto 0 0;
+  font-family: var(--font-bradford);
+  font-size: 1.35rem;
+  line-height: 1.16;
+}
+
+.style-route .body-copy {
+  color: rgb(255 255 255 / 70%);
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+}
+
+.landing-section {
+  margin-inline: calc(50% - 50vw);
+  padding-block: var(--spacing-40) var(--spacing-60);
+  background: var(--color-pure-white);
+}
+
+.landing-proof {
+  border-bottom: var(--border-subtle);
+}
+
+.section-kicker {
+  display: grid;
+  align-content: start;
+  gap: var(--spacing-8);
+}
+
+.work-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--spacing-16);
+  border-top: 0;
+}
+
+.work-preview-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(10rem, 1.12fr) minmax(0, 1fr);
+  gap: var(--spacing-20);
+  min-height: 11rem;
+  border: var(--border-subtle);
+  border-radius: 8px;
+  padding: var(--spacing-16);
+  color: var(--color-black-ink);
+  text-decoration: none;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease,
+    transform 180ms cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+
+.work-preview-media {
+  display: grid;
+  align-items: center;
+  min-height: 8.5rem;
+  border: var(--border-subtle);
+  border-radius: 8px;
+  padding: var(--spacing-20);
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 72%), rgb(255 255 255 / 34%)),
+    var(--color-frost-gray);
+}
+
+.work-preview-media-bars {
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 72%), rgb(255 255 255 / 34%)),
+    rgb(235 240 246);
+}
+
+.work-preview-media-headshots {
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 78%), rgb(255 255 255 / 28%)),
+    rgb(239 237 231);
+}
+
+.mini-app-shell,
+.mini-list-shell,
+.mini-profile-shell {
+  display: grid;
+  width: 100%;
+  border-radius: 8px;
+  padding: var(--spacing-12);
+  background: rgb(255 255 255 / 76%);
+}
+
+.mini-app-shell {
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--spacing-8);
+  align-items: end;
+  min-height: 5.75rem;
+}
+
+.mini-app-shell span {
+  min-height: var(--bar-height, 2rem);
+  border-radius: 6px 6px 0 0;
+  background: rgb(18 59 86 / 18%);
+}
+
+.mini-app-shell span:nth-child(2) {
+  --bar-height: 3.75rem;
+}
+
+.mini-app-shell span:nth-child(3) {
+  --bar-height: 2.5rem;
+}
+
+.mini-app-shell span:nth-child(4) {
+  --bar-height: 4.5rem;
+}
+
+.mini-app-shell span:nth-child(5) {
+  --bar-height: 3.25rem;
+}
+
+.mini-list-shell {
+  gap: var(--spacing-8);
+}
+
+.mini-list-shell span {
+  min-height: 0.875rem;
+  border-radius: 999px;
+  background: rgb(16 22 36 / 12%);
+}
+
+.mini-list-shell span:nth-child(odd) {
+  width: 72%;
+}
+
+.mini-profile-shell {
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-8);
+  align-items: end;
+  min-height: 5.75rem;
+}
+
+.mini-profile-shell span {
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: linear-gradient(145deg, rgb(47 98 83 / 28%), rgb(232 202 98 / 34%));
+}
+
+.work-preview-copy {
+  display: grid;
+  align-content: start;
+  gap: var(--spacing-8);
+  padding-right: var(--spacing-16);
+}
+
+.work-preview-title,
+.position-title {
+  margin: 0;
+  font-family: var(--font-bradford);
+  font-size: 1.65rem;
+  line-height: 1.12;
+}
+
+.work-preview-card .body-copy,
+.position-item .body-copy {
+  font-family: var(--font-labil);
+  font-size: var(--text-caption);
+}
+
+.work-preview-arrow {
+  align-self: start;
+  font-family: var(--font-labil);
+  font-size: 1.125rem;
+  line-height: 1;
+  position: absolute;
+  right: var(--spacing-16);
+  bottom: var(--spacing-16);
+  transition: transform 180ms cubic-bezier(0.215, 0.61, 0.355, 1);
+}
+
+.position-section {
+  margin-inline: calc(50% - 50vw);
+  border-top: var(--border-subtle);
+  padding-block: var(--spacing-60);
+  background: var(--color-frost-gray);
+}
+
+.position-grid {
+  display: grid;
+  grid-template-columns: minmax(14rem, 0.72fr) minmax(0, 1.8fr);
+  gap: var(--spacing-40);
+}
+
+.position-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--spacing-40);
+  border-top: 0;
+}
+
+.position-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-content: start;
+  gap: var(--spacing-16);
+  border-right: var(--border-subtle);
+  padding-right: var(--spacing-30);
+}
+
+.position-item:last-child {
+  border-right: 0;
+}
+
+.position-mark {
+  margin: 0;
+  color: var(--color-black-ink);
+  font-family: var(--font-labil);
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .button:hover {
+    @apply button-hover;
+  }
+
+  .work-card .button:hover {
+    background: transparent;
+    color: #ff4617;
+    transform: none;
+  }
+
+  .button-pill:hover {
+    border-color: var(--color-black-ink);
+    background: var(--color-black-ink);
+  }
+
+  .button-highlight:hover {
+    background: var(--color-electric-purple);
+    color: var(--color-pure-white);
+  }
+
+  .style-route:hover {
+    background: rgb(255 255 255 / 10%);
+    transform: translateY(-0.25rem);
+  }
+
+  .work-preview-card:hover {
+    color: var(--color-electric-purple);
+    transform: translateX(0.5rem);
+  }
+
+  .work-preview-card:hover .work-preview-arrow {
+    transform: translateX(0.25rem);
+  }
+
+  .work-card:hover .work-card-media {
+    box-shadow: 0 0 0 1px rgb(16 22 36 / 18%);
+    transform: translateY(-0.12rem);
+  }
+
+  .work-card:hover .heading a {
+    color: #ff4617;
+  }
+
+  .scrapbook-stage:hover .paper-card-main {
+    box-shadow: 0 1.8rem 4rem rgb(16 22 36 / 10%), 0 0 0 1px rgb(16 22 36 / 12%);
+  }
+
+  .scrapbook-stage:hover .paper-card-note,
+  .scrapbook-stage:hover .paper-card-name,
+  .scrapbook-stage:hover .paper-card-stamp,
+  .scrapbook-stage:hover .paper-card-doodle {
+    box-shadow: 0 1rem 2.5rem rgb(16 22 36 / 9%);
+  }
 }
 
 @utility editorial-hero {
   display: grid;
-  grid-template-columns: minmax(0, 7fr) minmax(17rem, 5fr);
-  gap: var(--spacing-40);
-  align-items: end;
-  min-height: clamp(32rem, 72svh, 46rem);
+  grid-template-columns: minmax(0, 1.05fr) minmax(17rem, 0.95fr);
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: start;
+  min-height: auto;
 }
 
 @utility editorial-panel {
   display: grid;
   gap: var(--spacing-20);
-  border: var(--border-ink);
+  border: 1px solid rgb(16 22 36 / 12%);
   padding: var(--spacing-20);
-  background: var(--color-pure-white);
+  background: #fffaf0;
+}
+
+.page-hero {
+  position: relative;
+  margin-block: clamp(2rem, 5vw, 4rem);
+  padding: clamp(2rem, 4vw, 3.5rem);
+  background: #fffaf0;
+  box-shadow: 0 0 0 1px rgb(16 22 36 / 10%);
+}
+
+.page-hero::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: clamp(1.4rem, 3vw, 3.5rem);
+  background: #ff4617;
+  content: "";
+}
+
+.page-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.page-hero .display {
+  max-width: 12ch;
+}
+
+.page-hero .body-copy {
+  max-width: 44rem;
+}
+
+.work-wall-section {
+  padding-top: 0;
 }
 
 @utility stat-row {
@@ -575,6 +1672,54 @@ button {
   gap: var(--spacing-20);
 }
 
+.post-masonry {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(1.5rem, 3vw, 2rem);
+  align-items: start;
+  content-visibility: auto;
+  contain-intrinsic-size: 56rem;
+}
+
+.post-masonry-column {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.post-masonry-column:nth-child(2) {
+  padding-top: clamp(1rem, 3vw, 2.4rem);
+}
+
+.post-masonry .card {
+  width: 100%;
+}
+
+.post-masonry .card-media {
+  aspect-ratio: 4 / 3;
+}
+
+.post-masonry-item:nth-child(4n + 1) .card-media {
+  aspect-ratio: 1.32 / 1;
+}
+
+.post-masonry-item:nth-child(4n + 2) .card-media {
+  aspect-ratio: 1 / 1.08;
+}
+
+.post-masonry-column:nth-child(2) .post-masonry-item:nth-child(4n + 1) .card-media {
+  aspect-ratio: 1.42 / 1;
+}
+
+.post-masonry-column:nth-child(2) .post-masonry-item:nth-child(4n + 2) .card-media {
+  aspect-ratio: 1 / 1.35;
+}
+
+.post-masonry .heading {
+  max-width: 22ch;
+  font-size: clamp(1.6rem, 2.3vw, 2.25rem);
+  line-height: 1.08;
+}
+
 @utility token-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 12rem), 1fr));
@@ -598,14 +1743,14 @@ button {
 @utility rule-list {
   display: grid;
   gap: 0;
-  border-top: var(--border-ink);
+  border-top: 1px solid rgb(16 22 36 / 12%);
 }
 
 @utility rule-item {
   display: grid;
   grid-template-columns: minmax(8rem, 1fr) minmax(0, 2fr);
   gap: var(--spacing-20);
-  border-bottom: var(--border-ink);
+  border-bottom: 1px solid rgb(16 22 36 / 12%);
   padding-block: var(--spacing-16);
 }
 
@@ -766,11 +1911,15 @@ button {
 }
 
 @media (max-width: 760px) {
+  :root {
+    --text-heading: 1.55rem;
+    --text-display: 3.2rem;
+  }
+
   .page-shell {
     width: min(100% - 1.5rem, var(--page-max-width));
   }
 
-  .site-header-inner,
   .site-footer-inner {
     align-items: flex-start;
     flex-direction: column;
@@ -778,21 +1927,161 @@ button {
     padding-block: var(--spacing-12);
   }
 
+  .site-header {
+    top: 0;
+  }
+
+  .site-header-inner {
+    width: min(100% - 1rem, var(--page-max-width));
+    gap: var(--spacing-8);
+  }
+
   .site-nav {
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    gap: var(--spacing-12);
+  }
+
+  .site-nav-link {
+    display: inline-flex;
+  }
+
+  .site-nav-cta {
+    min-height: 2.125rem;
+    padding-inline: var(--spacing-16);
   }
 
   .site-main {
     padding-block: var(--spacing-40) var(--spacing-60);
   }
 
+  .site-main:has(.scrapbook-hero) {
+    padding-block: 0;
+  }
+
+  .scrapbook-hero {
+    min-height: 42rem;
+    padding: 3rem 1rem;
+  }
+
+  .scrapbook-stage {
+    width: min(100%, 24rem);
+    min-height: 36rem;
+  }
+
+  .paper-card-main {
+    left: 1rem;
+    top: 3.4rem;
+    width: 20rem;
+    min-height: 18rem;
+    padding: 2.1rem 1.6rem 2rem 4.9rem;
+  }
+
+  .paper-card-main h1 {
+    font-size: 2.15rem;
+  }
+
+  .paper-card-main::after {
+    inset: 2.3rem 1.5rem 2rem 4.6rem;
+    background:
+      linear-gradient(rgb(16 22 36 / 12%) 1px, transparent 1px) 0 2.45rem / 100% 2.85rem,
+      linear-gradient(90deg, rgb(255 70 23 / 28%) 0 0.22rem, transparent 0.22rem) 0 0 / 100% 100%;
+  }
+
+  .paper-kicker {
+    font-size: 0.78rem;
+  }
+
+  .paper-card-note {
+    right: 0;
+    top: 22.6rem;
+    width: 19rem;
+    padding: 1.35rem 1.4rem 2.9rem;
+  }
+
+  .paper-card-note p {
+    font-size: 1rem;
+  }
+
+  .paper-card-note::before {
+    right: 3.45rem;
+    bottom: 0.85rem;
+    font-size: 0.68rem;
+  }
+
+  .paper-card-name {
+    right: 0;
+    top: 0.7rem;
+    width: 6.5rem;
+    min-height: 3.8rem;
+    font-size: 1.6rem;
+  }
+
+  .paper-card-stamp {
+    right: 0.2rem;
+    top: 14rem;
+    width: max-content;
+    padding: 0.55rem 0.7rem;
+    font-size: 0.75rem;
+  }
+
+  .paper-card-doodle {
+    left: 0.2rem;
+    top: 29rem;
+    width: 6.4rem;
+    height: 6.4rem;
+  }
+
+  .project-wall {
+    padding-inline: 0.75rem;
+  }
+
+  .project-grid {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-40);
+  }
+
+  .project-tile:nth-child(even) {
+    transform: none;
+  }
+
+  .project-visual {
+    min-height: 18rem;
+  }
+
   .editorial-hero,
   .grid-three,
-  .work-card,
+  .work-list,
   .work-gallery,
   .work-proof-grid,
   .rule-item {
     grid-template-columns: 1fr;
+  }
+
+  .work-card:nth-child(even) {
+    transform: none;
+  }
+
+  .work-card-media {
+    width: 100%;
+    min-height: 10rem;
+    aspect-ratio: 16 / 9;
+  }
+
+  .post-masonry {
+    grid-template-columns: 1fr;
+  }
+
+  .post-masonry-column {
+    gap: var(--spacing-40);
+  }
+
+  .post-masonry-column:nth-child(2) {
+    padding-top: 0;
+  }
+
+  .post-masonry-column:nth-child(n) .post-masonry-item:nth-child(n) .card-media {
+    aspect-ratio: 4 / 3;
   }
 
   .work-proof-panel + .work-proof-panel {
@@ -810,5 +2099,69 @@ button {
 
   .section-taupe {
     padding-inline: 0.75rem;
+  }
+
+  .home-shell {
+    width: min(100% - 1.5rem, var(--page-max-width));
+  }
+
+  .landing-hero {
+    padding-block: 7rem var(--spacing-40);
+  }
+
+  .landing-hero-grid,
+  .explore-grid,
+  .style-route-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-copy .display {
+    font-size: var(--text-display);
+  }
+
+  .work-preview-grid,
+  .work-preview-card,
+  .position-grid,
+  .position-list {
+    grid-template-columns: 1fr;
+  }
+
+  .work-preview-card {
+    min-height: auto;
+  }
+
+  .position-list {
+    border-left: 0;
+  }
+
+  .position-item {
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: var(--spacing-8);
+    min-height: auto;
+    border-right: 0;
+    border-bottom: var(--border-subtle);
+    padding: var(--spacing-20) 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-copy,
+  .landing-brief,
+  .style-route,
+  .landing-section,
+  .position-section {
+    animation: none;
+  }
+
+  .button,
+  .style-route,
+  .work-preview-card,
+  .paper-card,
+  .work-preview-arrow {
+    transition: none;
+  }
+
+  .custom-cursor {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary

- Rebuilds the landing page into a scrapbook-style editorial portfolio with interactive paper cards, custom cursor behavior, and hover/focus link prefetching.
- Updates Work, Writing, and About surfaces to share the new visual language, including Work cards aligned to Writing cards and a two-column editorial masonry Writing index.
- Extracts Work/Writing page data shaping into feature modules so route files stay focused on fetching and rendering.
- Moves browser interactions into a cacheable static script and removes the unused `styled-components` dependency.

## Verification

- `bun run build`
- Smoke tested `/`, `/work`, `/writing`, and `/about` locally: all returned 200 with no page or console errors.
- Deployed to Cloudflare Workers: https://dhafin-personal-site.dhiodhaha.workers.dev

## Deploy

Cloudflare Workers version: `ed6e2758-4d1a-4f78-890f-7c741f30622d`