### PR TITLE
Configure Cloudflare Worker custom domains

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,28 @@ compatibility_date = "2026-05-02"
 [assets]
 directory = "dist"
 not_found_handling = "single-page-application"
+
+[[routes]]
+pattern = "dhaf.in"
+custom_domain = true
+zone_name = "dhaf.in"
+
+[[routes]]
+pattern = "www.dhaf.in"
+custom_domain = true
+zone_name = "dhaf.in"
+
+[[routes]]
+pattern = "portfolio.dhaf.in"
+custom_domain = true
+zone_name = "dhaf.in"
+
+[[routes]]
+pattern = "video.dhaf.in"
+custom_domain = true
+zone_name = "dhaf.in"
+
+[[routes]]
+pattern = "midjourney.dhaf.in"
+custom_domain = true
+zone_name = "dhaf.in"


### PR DESCRIPTION
## What changed

- Added Cloudflare Worker custom-domain routes for:
  - `dhaf.in`
  - `www.dhaf.in`
  - `portfolio.dhaf.in`
  - `video.dhaf.in`
  - `midjourney.dhaf.in`
- Each route uses `custom_domain = true` and explicit `zone_name = "dhaf.in"`.

## Current blocker

Deploy fails until `dhaf.in` exists as a Cloudflare zone. Current DNS still uses Vercel nameservers:

```txt
ns1.vercel-dns.com
ns2.vercel-dns.com
```

Cloudflare error:

```txt
Could not find zone for `dhaf.in`. Make sure the domain is set up to be proxied by Cloudflare.
```

## Manual step before merge

- Add `dhaf.in` to Cloudflare as a zone.
- Copy Vercel DNS + Lark Mail records into Cloudflare.
- Change Porkbun nameservers to Cloudflare.
- Rerun `bun run build && bun run cf:deploy`.

## Validation

- [x] `bun run build`
- [x] `bun run cf:deploy` uploads Worker but fails on missing Cloudflare zone, as expected before DNS migration.