### PR TITLE
Fix Cloudflare middleware redirects

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, sessionDrivers } from 'astro/config';
 
 export default defineConfig({
+  output: 'server',
   site: process.env.PUBLIC_SITE_URL || 'https://dhaf.in',
   integrations: [sitemap()],
   prefetch: {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,7 @@ compatibility_date = "2026-05-02"
 [assets]
 directory = "dist"
 not_found_handling = "single-page-application"
+run_worker_first = true
 
 [[routes]]
 pattern = "dhaf.in"


### PR DESCRIPTION
## What changed

- Switched Astro to `output: server` so middleware runs at request time on Cloudflare Workers.
- Enabled `assets.run_worker_first` so custom-domain redirect middleware runs before static asset serving.

## Why

The custom domains were live, but legacy hosts returned static `200` pages because Astro was still building static output and Cloudflare assets were served before middleware.

## Validation

- `rtk bun run build`
- Deployed Worker version `d8c15277-cb85-45e6-a398-218a17ec82b2`
- `dhaf.in` returns `200`
- `www.dhaf.in` redirects to `https://dhaf.in/`
- `portfolio.dhaf.in` redirects to `https://dhaf.in/work`
- `video.dhaf.in` redirects to `https://dhaf.in/about`
- `midjourney.dhaf.in` redirects to `https://dhaf.in/about`