### PR TITLE
Configure Cloudflare runtime vars

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,12 @@
 name = "dhafin-personal-site"
 compatibility_date = "2026-05-02"
 
+[vars]
+PUBLIC_SITE_URL = "https://dhaf.in"
+SANITY_STUDIO_PROJECT_ID = "a7az8pap"
+SANITY_STUDIO_DATASET = "production"
+SANITY_API_VERSION = "2025-02-19"
+
 [assets]
 directory = "dist"
 not_found_handling = "single-page-application"


### PR DESCRIPTION
## What changed

- Added non-secret Cloudflare runtime vars to `wrangler.toml`.
- Pushed `SANITY_READ_TOKEN` and `PREVIEW_SECRET` to Cloudflare Worker secrets.

## Why

Astro now runs as server output on Cloudflare, so published Sanity content is fetched at request time. The Worker needs the Sanity project config in runtime env.

## Validation

- `rtk bun run build`
- `rtk bun run cf:deploy`
- Cloudflare deployment `306c1719-6c38-424e-9e6c-7c0e6f58e0fe` shows expected runtime vars.
- `https://dhaf.in/writing` shows seeded post: `What video work taught me about product building`.
- `https://dhaf.in/work` shows seeded work: `Invitasi`, `Devault`, `Standout`.