### PR TITLE
Fix Sanity env access on Cloudflare

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,11 +1,28 @@
 import cloudflare from '@astrojs/cloudflare';
 import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
-import { defineConfig, sessionDrivers } from 'astro/config';
+import { defineConfig, envField, sessionDrivers } from 'astro/config';
 
 export default defineConfig({
   output: 'server',
   site: process.env.PUBLIC_SITE_URL || 'https://dhaf.in',
+  env: {
+    schema: {
+      PREVIEW_SECRET: envField.string({ context: 'server', access: 'secret' }),
+      SANITY_API_VERSION: envField.string({
+        context: 'server',
+        access: 'public',
+        default: '2025-02-19',
+      }),
+      SANITY_READ_TOKEN: envField.string({ context: 'server', access: 'secret' }),
+      SANITY_STUDIO_DATASET: envField.string({
+        context: 'server',
+        access: 'public',
+        default: 'production',
+      }),
+      SANITY_STUDIO_PROJECT_ID: envField.string({ context: 'server', access: 'public' }),
+    },
+  },
   integrations: [sitemap()],
   prefetch: {
     prefetchAll: true,

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -5,7 +5,6 @@ import {
   PREVIEW_MAX_AGE_SECONDS,
   PreviewContentConfigError,
   createPreviewToken,
-  getAstroRuntimeEnv,
   getPreviewSanityEnv,
   type PreviewContentType,
 } from '../../sanity/preview';
@@ -38,8 +37,7 @@ function safeEqual(left: string, right: string): boolean {
   return mismatch === 0;
 }
 
-export const GET: APIRoute = async ({ cookies, locals, redirect, request }) => {
-  const runtimeEnv = getAstroRuntimeEnv(locals);
+export const GET: APIRoute = async ({ cookies, redirect, request }) => {
   const url = new URL(request.url);
   const secret = url.searchParams.get('secret');
   const slug = url.searchParams.get('slug');
@@ -50,13 +48,13 @@ export const GET: APIRoute = async ({ cookies, locals, redirect, request }) => {
   }
 
   try {
-    const { previewSecret } = getPreviewSanityEnv(runtimeEnv);
+    const { previewSecret } = getPreviewSanityEnv();
 
     if (!safeEqual(secret, previewSecret)) {
       return new Response('Invalid preview secret.', { status: 401 });
     }
 
-    const token = await createPreviewToken({ slug, type }, runtimeEnv);
+    const token = await createPreviewToken({ slug, type });
 
     cookies.set(PREVIEW_COOKIE_NAME, token, {
       httpOnly: true,

--- a/src/pages/preview/work/[slug].astro
+++ b/src/pages/preview/work/[slug].astro
@@ -6,7 +6,6 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import {
   PREVIEW_COOKIE_NAME,
   PreviewContentConfigError,
-  getAstroRuntimeEnv,
   getPreviewWorkBySlug,
   isPreviewAuthorized,
 } from '../../../sanity/preview';
@@ -20,11 +19,10 @@ if (!slug) {
   return new Response('Missing preview slug.', { status: 400 });
 }
 
-const runtimeEnv = getAstroRuntimeEnv(Astro.locals);
 const previewCookie = Astro.cookies.get(PREVIEW_COOKIE_NAME)?.value;
 
 try {
-  const authorized = await isPreviewAuthorized(previewCookie, 'work', slug, runtimeEnv);
+  const authorized = await isPreviewAuthorized(previewCookie, 'work', slug);
 
   if (!authorized) {
     return new Response('Preview authorization required.', { status: 401 });
@@ -37,7 +35,7 @@ try {
   throw error;
 }
 
-const work = await getPreviewWorkBySlug(slug, runtimeEnv);
+const work = await getPreviewWorkBySlug(slug);
 
 if (!work) {
   return new Response('Preview work document not found.', { status: 404 });

--- a/src/pages/preview/writing/[slug].astro
+++ b/src/pages/preview/writing/[slug].astro
@@ -5,7 +5,6 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import {
   PREVIEW_COOKIE_NAME,
   PreviewContentConfigError,
-  getAstroRuntimeEnv,
   getPreviewPostBySlug,
   isPreviewAuthorized,
 } from '../../../sanity/preview';
@@ -18,11 +17,10 @@ if (!slug) {
   return new Response('Missing preview slug.', { status: 400 });
 }
 
-const runtimeEnv = getAstroRuntimeEnv(Astro.locals);
 const previewCookie = Astro.cookies.get(PREVIEW_COOKIE_NAME)?.value;
 
 try {
-  const authorized = await isPreviewAuthorized(previewCookie, 'writing', slug, runtimeEnv);
+  const authorized = await isPreviewAuthorized(previewCookie, 'writing', slug);
 
   if (!authorized) {
     return new Response('Preview authorization required.', { status: 401 });
@@ -35,7 +33,7 @@ try {
   throw error;
 }
 
-const post = await getPreviewPostBySlug(slug, runtimeEnv);
+const post = await getPreviewPostBySlug(slug);
 
 if (!post) {
   return new Response('Preview writing document not found.', { status: 404 });

--- a/src/sanity/preview/env.ts
+++ b/src/sanity/preview/env.ts
@@ -1,3 +1,11 @@
+import {
+  PREVIEW_SECRET,
+  SANITY_API_VERSION,
+  SANITY_READ_TOKEN,
+  SANITY_STUDIO_DATASET,
+  SANITY_STUDIO_PROJECT_ID,
+} from 'astro:env/server';
+
 export type RuntimeEnv = Record<string, string | undefined>;
 
 export type PreviewSanityEnv = {
@@ -8,9 +16,6 @@ export type PreviewSanityEnv = {
   readToken: string;
 };
 
-const DEFAULT_API_VERSION = '2025-02-19';
-const DEFAULT_DATASET = 'production';
-
 export class PreviewContentConfigError extends Error {
   constructor(message: string) {
     super(`Preview Sanity content is not configured: ${message}`);
@@ -18,13 +23,7 @@ export class PreviewContentConfigError extends Error {
   }
 }
 
-function readEnv(name: string, runtimeEnv?: RuntimeEnv): string | undefined {
-  return runtimeEnv?.[name] ?? process.env[name];
-}
-
-function requiredEnv(name: string, runtimeEnv?: RuntimeEnv): string {
-  const value = readEnv(name, runtimeEnv);
-
+function requiredEnv(name: string, value: string | undefined): string {
   if (!value) {
     throw new PreviewContentConfigError(`Missing ${name}.`);
   }
@@ -32,22 +31,15 @@ function requiredEnv(name: string, runtimeEnv?: RuntimeEnv): string {
   return value;
 }
 
-export function getAstroRuntimeEnv(locals: unknown): RuntimeEnv | undefined {
-  if (typeof locals !== 'object' || locals === null) {
-    return undefined;
-  }
-
-  const runtime = (locals as { runtime?: { env?: RuntimeEnv } }).runtime;
-
-  return runtime?.env;
-}
-
 export function getPreviewSanityEnv(runtimeEnv?: RuntimeEnv): PreviewSanityEnv {
   return {
-    apiVersion: readEnv('SANITY_API_VERSION', runtimeEnv) ?? DEFAULT_API_VERSION,
-    dataset: readEnv('SANITY_STUDIO_DATASET', runtimeEnv) ?? DEFAULT_DATASET,
-    previewSecret: requiredEnv('PREVIEW_SECRET', runtimeEnv),
-    projectId: requiredEnv('SANITY_STUDIO_PROJECT_ID', runtimeEnv),
-    readToken: requiredEnv('SANITY_READ_TOKEN', runtimeEnv),
+    apiVersion: runtimeEnv?.SANITY_API_VERSION ?? SANITY_API_VERSION,
+    dataset: runtimeEnv?.SANITY_STUDIO_DATASET ?? SANITY_STUDIO_DATASET,
+    previewSecret: requiredEnv('PREVIEW_SECRET', runtimeEnv?.PREVIEW_SECRET ?? PREVIEW_SECRET),
+    projectId: requiredEnv(
+      'SANITY_STUDIO_PROJECT_ID',
+      runtimeEnv?.SANITY_STUDIO_PROJECT_ID ?? SANITY_STUDIO_PROJECT_ID,
+    ),
+    readToken: requiredEnv('SANITY_READ_TOKEN', runtimeEnv?.SANITY_READ_TOKEN ?? SANITY_READ_TOKEN),
   };
 }

--- a/src/sanity/preview/index.ts
+++ b/src/sanity/preview/index.ts
@@ -6,6 +6,6 @@ export {
   verifyPreviewToken,
 } from './auth';
 export type { PreviewContentType, PreviewTokenPayload } from './auth';
-export { PreviewContentConfigError, getAstroRuntimeEnv, getPreviewSanityEnv } from './env';
+export { PreviewContentConfigError, getPreviewSanityEnv } from './env';
 export type { PreviewSanityEnv, RuntimeEnv } from './env';
 export { getPreviewPostBySlug, getPreviewWorkBySlug } from './fetch';

--- a/src/sanity/published/env.ts
+++ b/src/sanity/published/env.ts
@@ -1,3 +1,9 @@
+import {
+  SANITY_API_VERSION,
+  SANITY_STUDIO_DATASET,
+  SANITY_STUDIO_PROJECT_ID,
+} from 'astro:env/server';
+
 import { PublishedContentConfigError } from './errors';
 
 export type PublishedSanityEnv = {
@@ -6,19 +12,14 @@ export type PublishedSanityEnv = {
   projectId: string;
 };
 
-const DEFAULT_API_VERSION = '2025-02-19';
-const DEFAULT_DATASET = 'production';
-
 export function getPublishedSanityEnv(): PublishedSanityEnv {
-  const projectId = process.env.SANITY_STUDIO_PROJECT_ID;
-
-  if (!projectId) {
+  if (!SANITY_STUDIO_PROJECT_ID) {
     throw new PublishedContentConfigError('Missing SANITY_STUDIO_PROJECT_ID.');
   }
 
   return {
-    apiVersion: process.env.SANITY_API_VERSION ?? DEFAULT_API_VERSION,
-    dataset: process.env.SANITY_STUDIO_DATASET ?? DEFAULT_DATASET,
-    projectId,
+    apiVersion: SANITY_API_VERSION,
+    dataset: SANITY_STUDIO_DATASET,
+    projectId: SANITY_STUDIO_PROJECT_ID,
   };
 }


### PR DESCRIPTION
## What changed

- Added Astro `env.schema` for Sanity and preview runtime values.
- Replaced deprecated `Astro.locals.runtime` env plumbing with `astro:env/server`.
- Removed page-level runtime env threading from published and preview routes.

## Why

Astro 6 removed `Astro.locals.runtime`; the previous implementation caused published pages to fall back instead of reading Cloudflare runtime env correctly. `astro:env/server` is the documented typed env API and is compatible with Cloudflare bindings.

## Validation

- Checked Astro environment variable docs and Cloudflare adapter env docs.
- `rtk bun run build` passed.
- Deployed Worker version `6f3990bd-de4c-49be-9759-94c7e904f5df`.
- `https://dhaf.in/writing` renders all five seeded post titles.
- `https://dhaf.in/work` still renders `Invitasi`, `Devault`, and `Standout`.
- Confirmed no `Astro.locals.runtime`, `getAstroRuntimeEnv`, or `cloudflare:workers` imports remain in app code.