### PR TITLE
Refine post page typography

### DIFF
--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -40,9 +40,9 @@ const socialImage = post.coverImage
 ---
 
 <BaseLayout title={post.title} description={post.excerpt} image={socialImage} type="article">
-  <article class="section" aria-labelledby="post-title">
-    <header class="editorial-hero">
-      <div class="section">
+  <article class="section post-detail" aria-labelledby="post-title">
+    <header class="editorial-hero post-detail-hero">
+      <div class="section post-detail-copy">
         <p class="eyebrow">{post.category.title} / {publishedDate}</p>
         <h1 id="post-title" class="display">{post.title}</h1>
         <p class="body-copy">{post.excerpt}</p>

--- a/src/styles/components/editorial.css
+++ b/src/styles/components/editorial.css
@@ -14,6 +14,35 @@
   background: #fffaf0;
 }
 
+@utility post-detail {
+  gap: clamp(2.5rem, 6vw, 4.5rem);
+}
+
+@utility post-detail-hero {
+  padding-bottom: clamp(1.5rem, 4vw, 3rem);
+  border-bottom: var(--border-subtle);
+}
+
+@utility post-detail-copy {
+  align-content: start;
+  gap: var(--spacing-16);
+  max-width: 46rem;
+}
+
+.post-detail-copy .display {
+  max-width: 13ch;
+  color: rgb(16 22 36 / 72%);
+  font-size: clamp(3.1rem, 6vw, 5.7rem);
+  line-height: 0.96;
+}
+
+.post-detail-copy .body-copy {
+  max-width: 42rem;
+  color: rgb(16 22 36 / 56%);
+  font-size: clamp(1.06rem, 1.4vw, 1.22rem);
+  line-height: 1.5;
+}
+
 .page-hero {
   position: relative;
   margin-block: clamp(2rem, 5vw, 4rem);

--- a/src/styles/components/rich-text.css
+++ b/src/styles/components/rich-text.css
@@ -1,7 +1,7 @@
 @utility rich-text {
   display: grid;
-  gap: var(--spacing-20);
-  max-width: 760px;
+  gap: var(--spacing-30);
+  width: min(100%, 42rem);
 }
 
 .rich-text > p,
@@ -10,27 +10,31 @@
 .rich-callout p {
   margin: 0;
   color: var(--color-black-ink);
-  font-family: var(--font-bradford);
-  font-size: var(--text-body);
-  line-height: 1.7;
+  font-family: var(--font-labil);
+  font-size: clamp(1.03rem, 1vw, 1.08rem);
+  line-height: 1.72;
   letter-spacing: var(--tracking-body);
+  text-wrap: pretty;
 }
 
 @utility rich-heading {
-  margin: var(--spacing-20) 0 0;
-  font-family: var(--font-labilvariable);
-  font-size: var(--text-heading);
+  margin: var(--spacing-30) 0 0;
+  max-width: 17ch;
+  color: rgb(16 22 36 / 72%);
+  font-family: var(--font-bradford);
+  font-size: clamp(2rem, 4vw, 3.35rem);
   font-weight: 400;
-  line-height: var(--leading-heading);
+  line-height: 1.02;
   letter-spacing: var(--tracking-heading);
+  text-wrap: balance;
 }
 
 @utility rich-subheading {
-  margin: var(--spacing-10) 0 0;
+  margin: var(--spacing-20) 0 0;
   font-family: var(--font-labil);
-  font-size: var(--text-body);
-  font-weight: 500;
-  line-height: var(--leading-body);
+  font-size: var(--text-meta);
+  font-weight: 700;
+  line-height: var(--leading-meta);
   letter-spacing: var(--tracking-meta);
   text-transform: uppercase;
 }
@@ -42,16 +46,18 @@
 }
 
 @utility rich-quote {
-  border-left: 4px solid var(--color-electric-purple);
-  padding-left: var(--spacing-20);
+  border-left: 0.25rem solid var(--color-electric-purple);
+  padding: var(--spacing-8) 0 var(--spacing-8) var(--spacing-20);
   color: var(--color-medium-gray);
-  font-size: 1.25rem;
+  font-family: var(--font-bradford);
+  font-size: clamp(1.3rem, 2.5vw, 1.85rem);
+  line-height: 1.25;
 }
 
 @utility rich-figure {
   display: grid;
   gap: var(--spacing-8);
-  margin: var(--spacing-20) 0;
+  margin: var(--spacing-10) 0;
 }
 
 .rich-figure img,
@@ -102,6 +108,11 @@
   border: var(--border-ink);
   padding: var(--spacing-20);
   background: var(--color-muted-taupe);
+}
+
+.rich-callout p {
+  font-size: var(--text-body);
+  line-height: var(--leading-body);
 }
 
 @utility rich-callout-product {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -70,6 +70,23 @@
     min-height: auto;
   }
 
+  .post-detail {
+    gap: var(--spacing-40);
+  }
+
+  .post-detail-hero {
+    gap: var(--spacing-30);
+  }
+
+  .post-detail-copy .display {
+    max-width: 12ch;
+  }
+
+  .rich-text {
+    gap: var(--spacing-20);
+    width: 100%;
+  }
+
   .stat-row {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## What changed

- Added dedicated post-detail layout classes for the individual writing page.
- Refined post hero typography so title and excerpt match the current editorial design language.
- Updated rich text typography: sans body copy for readability, Bradford serif for article headings and quotes, tighter article measure, and cleaner mobile rhythm.

## Why

The individual post page was visually inconsistent with the current site system. The typography mixed older article styles with the newer editorial direction, making the page feel less polished than the index and work pages.

## Validation

- `rtk bun run build` passed.
- Changes are scoped to the writing detail page and shared rich text styles.

## Notes

No content/schema changes. No Cloudflare env changes.